### PR TITLE
feat: add npm command prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Once you've started working, it's convenient to use `npm restart` (or `npm res` 
 	"wslUseExe": false,
 	// run `rbxtsc -w` + `rojo serve` automatically after Studio opens, default provided below
 	"watchOnOpen": true,
-	// optional prefix for the `rbxts-build` commands, e.g. "dev:" would run "dev:watch" instead of "watch", default provided below
-	"prefix": ""
+	// optionally provide a list of names to replace with their default values, an example is provided below
+	"names": { "build": "dev:build", "compile": "dev:compile", "open": "dev:open", "watch": "dev:watch" }
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Once you've started working, it's convenient to use `npm restart` (or `npm res` 
 	"wslUseExe": false,
 	// run `rbxtsc -w` + `rojo serve` automatically after Studio opens, default provided below
 	"watchOnOpen": true,
+	// optional prefix for the `rbxts-build` commands, e.g. "dev:" would run "dev:watch" instead of "watch", default provided below
+	"prefix": ""
 },
 ```
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,10 +3,10 @@ import fs from "fs/promises";
 import path from "path";
 import yargs from "yargs";
 import { identity } from "../util/identity";
+import { SCRIPT_NAMES } from "../typeChecks";
+import { getCommandName, getSettings } from "../util/getSettings";
 
 const command = "init";
-
-const SCRIPT_NAMES = ["compile", "build", "open", "start", "stop", "sync", "watch"];
 
 async function handler() {
 	const projectPath = process.cwd();
@@ -16,7 +16,10 @@ async function handler() {
 	const pkgJson = JSON.parse((await fs.readFile(pkgJsonPath)).toString());
 	pkgJson.scripts ??= {};
 
-	for (const scriptName of SCRIPT_NAMES) {
+	const settings = await getSettings(projectPath);
+
+	for (const defaultName of SCRIPT_NAMES) {
+		const scriptName = getCommandName(settings, defaultName);
 		if (pkgJson.scripts[scriptName] !== undefined) {
 			console.log(kleur.yellow("warning:"), `package.json script "${scriptName}" already exists, overwriting!`);
 			console.log(`\toriginal: "${pkgJson.scripts[scriptName]}"`);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,7 +4,8 @@ import path from "path";
 import yargs from "yargs";
 import { identity } from "../util/identity";
 import { SCRIPT_NAMES } from "../typeChecks";
-import { getCommandName, getSettings } from "../util/getSettings";
+import { getSettings } from "../util/getSettings";
+import { getCommandName } from "../util/getCommandName";
 
 const command = "init";
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -12,6 +12,7 @@ const command = "open";
 async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
+	const prefix = settings.prefix ?? "";
 
 	await runPlatform({
 		darwin: () => run("open", [PLACEFILE_NAME]),
@@ -23,7 +24,7 @@ async function handler() {
 	});
 
 	if (settings.watchOnOpen !== false) {
-		await run("npm", ["run", "watch", "--silent"]);
+		await run("npm", ["run", prefix + "watch", "--silent"]);
 	}
 }
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import yargs from "yargs";
 import { PLACEFILE_NAME } from "../constants";
-import { getSettings } from "../util/getSettings";
+import { getCommandName, getSettings } from "../util/getSettings";
 import { getWindowsPath } from "../util/getWindowsPath";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
@@ -12,7 +12,6 @@ const command = "open";
 async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
-	const prefix = settings.prefix ?? "";
 
 	await runPlatform({
 		darwin: () => run("open", [PLACEFILE_NAME]),
@@ -24,7 +23,7 @@ async function handler() {
 	});
 
 	if (settings.watchOnOpen !== false) {
-		await run("npm", ["run", prefix + "watch", "--silent"]);
+		await run("npm", ["run", getCommandName(settings, "watch"), "--silent"]);
 	}
 }
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,7 +1,8 @@
 import path from "path";
 import yargs from "yargs";
 import { PLACEFILE_NAME } from "../constants";
-import { getCommandName, getSettings } from "../util/getSettings";
+import { getSettings } from "../util/getSettings";
+import { getCommandName } from "../util/getCommandName";
 import { getWindowsPath } from "../util/getWindowsPath";
 import { identity } from "../util/identity";
 import { run } from "../util/run";

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,18 +1,17 @@
 import yargs from "yargs";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
-import { getSettings } from "../util/getSettings";
+import { getCommandName, getSettings } from "../util/getSettings";
 
 const command = "start";
 
 async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
-	const prefix = settings.prefix ?? "";
 
-	await run("npm", ["run", prefix + "compile", "--silent"]);
-	await run("npm", ["run", prefix + "build", "--silent"]);
-	await run("npm", ["run", prefix + "open", "--silent"]);
+	await run("npm", ["run", getCommandName(settings, "compile"), "--silent"]);
+	await run("npm", ["run", getCommandName(settings, "build"), "--silent"]);
+	await run("npm", ["run", getCommandName(settings, "open"), "--silent"]);
 }
 
 export = identity<yargs.CommandModule>({ command, handler });

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,7 +1,8 @@
 import yargs from "yargs";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
-import { getCommandName, getSettings } from "../util/getSettings";
+import { getSettings } from "../util/getSettings";
+import { getCommandName } from "../util/getCommandName";
 
 const command = "start";
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,13 +1,18 @@
 import yargs from "yargs";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
+import { getSettings } from "../util/getSettings";
 
 const command = "start";
 
 async function handler() {
-	await run("npm", ["run", "compile", "--silent"]);
-	await run("npm", ["run", "build", "--silent"]);
-	await run("npm", ["run", "open", "--silent"]);
+	const projectPath = process.cwd();
+	const settings = await getSettings(projectPath);
+	const prefix = settings.prefix ?? "";
+
+	await run("npm", ["run", prefix + "compile", "--silent"]);
+	await run("npm", ["run", prefix + "build", "--silent"]);
+	await run("npm", ["run", prefix + "open", "--silent"]);
 }
 
 export = identity<yargs.CommandModule>({ command, handler });

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -11,8 +11,9 @@ const command = "sync";
 async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
+	const prefix = settings.prefix ?? "";
 
-	await run("npm", ["run", "build", "--silent"]);
+	await run("npm", ["run", prefix + "build", "--silent"]);
 
 	const outPath = settings.syncLocation ?? "src/services.d.ts";
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,7 @@
 import yargs from "yargs";
 import { PLACEFILE_NAME, SYNC_SCRIPT_PATH } from "../constants";
-import { getCommandName, getSettings } from "../util/getSettings";
+import { getSettings } from "../util/getSettings";
+import { getCommandName } from "../util/getCommandName";
 import { getWindowsPath } from "../util/getWindowsPath";
 import { identity } from "../util/identity";
 import { run } from "../util/run";

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { PLACEFILE_NAME, SYNC_SCRIPT_PATH } from "../constants";
-import { getSettings } from "../util/getSettings";
+import { getCommandName, getSettings } from "../util/getSettings";
 import { getWindowsPath } from "../util/getWindowsPath";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
@@ -11,9 +11,8 @@ const command = "sync";
 async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
-	const prefix = settings.prefix ?? "";
 
-	await run("npm", ["run", prefix + "build", "--silent"]);
+	await run("npm", ["run", getCommandName(settings, "build"), "--silent"]);
 
 	const outPath = settings.syncLocation ?? "src/services.d.ts";
 

--- a/src/typeChecks.ts
+++ b/src/typeChecks.ts
@@ -1,5 +1,7 @@
 import * as z from "zod";
 
+export const SCRIPT_NAMES = ["compile", "build", "open", "start", "stop", "sync", "watch"];
+
 export const packageJsonType = z.object({
 	"rbxts-build": z
 		.object({
@@ -9,7 +11,7 @@ export const packageJsonType = z.object({
 			wslUseExe: z.boolean().optional(),
 			dev: z.boolean().optional(),
 			watchOnOpen: z.boolean().optional(),
-			prefix: z.string().optional(),
+			names: z.object(Object.fromEntries(SCRIPT_NAMES.map(name => [name, z.string().optional()]))).optional(),
 		})
 		.optional(),
 });

--- a/src/typeChecks.ts
+++ b/src/typeChecks.ts
@@ -9,6 +9,7 @@ export const packageJsonType = z.object({
 			wslUseExe: z.boolean().optional(),
 			dev: z.boolean().optional(),
 			watchOnOpen: z.boolean().optional(),
+			prefix: z.string().optional(),
 		})
 		.optional(),
 });

--- a/src/util/getCommandName.ts
+++ b/src/util/getCommandName.ts
@@ -1,0 +1,5 @@
+import { packageJsonType } from "../typeChecks";
+
+export function getCommandName(settings: packageJsonType["rbxts-build"], command: string) {
+	return settings?.names?.[command] ?? command;
+}

--- a/src/util/getSettings.ts
+++ b/src/util/getSettings.ts
@@ -8,3 +8,7 @@ export async function getSettings(projectPath: string) {
 	const pkgJson = packageJsonType.parse(JSON.parse(pkgJsonContents));
 	return pkgJson?.["rbxts-build"] ?? {};
 }
+
+export function getCommandName(settings: packageJsonType["rbxts-build"], command: string) {
+	return settings?.names?.[command] ?? command;
+}

--- a/src/util/getSettings.ts
+++ b/src/util/getSettings.ts
@@ -8,7 +8,3 @@ export async function getSettings(projectPath: string) {
 	const pkgJson = packageJsonType.parse(JSON.parse(pkgJsonContents));
 	return pkgJson?.["rbxts-build"] ?? {};
 }
-
-export function getCommandName(settings: packageJsonType["rbxts-build"], command: string) {
-	return settings?.names?.[command] ?? command;
-}


### PR DESCRIPTION
This PR gives the option to prepend all npm commands with a prefix, which is commonly used for npm command namespacing.