### PR TITLE
Add WSL File Sync Support for Studio Workflow

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,7 @@
 		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/interface-name-prefix": "off",
 		"@typescript-eslint/no-empty-function": "off",
-		"@typescript-eslint/no-empty-interface": "Off",
+		"@typescript-eslint/no-empty-interface": "off",
 		"@typescript-eslint/no-namespace": "off",
 		"@typescript-eslint/no-non-null-assertion": "off",
 		"@typescript-eslint/no-use-before-define": "off",

--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,5 @@
+{
+  "aliases": {
+    "lune": "~/.lune/.typedefs/0.9.4/"
+  }
+}

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,0 +1,7 @@
+# This file lists tools managed by Rokit, a toolchain manager for Roblox projects.
+# For more information, see https://github.com/rojo-rbx/rokit
+
+# New tools can be added by running `rokit add <tool>` in a terminal.
+
+[tools]
+lune = "lune-org/lune@0.9.4"

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import yargs from "yargs";
 import { PLACEFILE_NAME } from "../constants";
@@ -7,20 +8,48 @@ import { getWindowsPath } from "../util/getWindowsPath";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
 import { runPlatform } from "../util/runPlatform";
+import { shouldUseWindowsTemp, ensureWindowsAccessible } from "../util/wslFileSync";
 
 const command = "open";
+
+function assertFileExists(filePath: string) {
+	if (!fs.existsSync(filePath)) {
+		throw new Error(`File '${PLACEFILE_NAME}' does not exist. Run 'build' first to create the file.`);
+	}
+}
 
 async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
 
 	await runPlatform({
-		darwin: () => run("open", [PLACEFILE_NAME]),
-		linux: async () => {
-			const fsPath = await getWindowsPath(path.join(projectPath, PLACEFILE_NAME));
-			return run("powershell.exe", ["/c", `start ${fsPath}`]);
+		darwin: () => {
+			assertFileExists(PLACEFILE_NAME);
+			return run("open", [PLACEFILE_NAME]);
 		},
-		win32: () => run("start", [PLACEFILE_NAME]),
+		linux: async () => {
+			const placeFilePath = path.join(projectPath, PLACEFILE_NAME);
+			assertFileExists(placeFilePath);
+
+			if (shouldUseWindowsTemp(settings)) {
+				// Copy to Windows temp location first - this is currently
+				// required for sync to work
+				const windowsPath = await ensureWindowsAccessible(
+					placeFilePath,
+					settings.windowsSavePath,
+					settings.useWindowsTemp,
+				);
+				console.log(`File copied to Windows-accessible location: ${windowsPath}`);
+				return run("cmd.exe", ["/c", `start "" "${windowsPath}"`]);
+			}
+
+			const fsPath = await getWindowsPath(placeFilePath);
+			return run("cmd.exe", ["/c", `start "" "${fsPath}"`]);
+		},
+		win32: () => {
+			assertFileExists(PLACEFILE_NAME);
+			return run("start", [PLACEFILE_NAME]);
+		},
 	});
 
 	if (settings.watchOnOpen !== false) {

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,32 +1,118 @@
-import fs from "fs/promises";
 import path from "path";
 import yargs from "yargs";
-import { LOCKFILE_NAME } from "../constants";
+import { LOCKFILE_NAME, PLACEFILE_NAME } from "../constants";
+import { RbxtsBuildSettings } from "../typeChecks";
+import { getSettings } from "../util/getSettings";
 import { identity } from "../util/identity";
-import { run } from "../util/run";
-import { runPlatform } from "../util/runPlatform";
+import {
+	readProcessIdFromWindowsLockfile,
+	readProcessIdFromLockfile,
+	terminateStudioProcess,
+	cleanupWindowsLockfile,
+	cleanupLockfile,
+} from "../util/studioProcess";
+import { shouldUseWindowsTemp, getWindowsSafePath, checkWindowsFileExists } from "../util/wslFileSync";
 
 const command = "stop";
 
-async function handler() {
-	const projectPath = process.cwd();
+/**
+ * Attempts to stop Studio using Windows temp lockfile
+ * @param projectPath - The project directory path
+ * @param settings - Project settings
+ * @returns true if Studio was stopped, false if no lockfile found
+ */
+async function tryStopWindowsTempStudio(projectPath: string, settings: RbxtsBuildSettings): Promise<boolean> {
+	if (!shouldUseWindowsTemp(settings)) {
+		return false;
+	}
 
+	try {
+		const placeFilePath = path.join(projectPath, PLACEFILE_NAME);
+		const windowsFilePath = await getWindowsSafePath(
+			placeFilePath,
+			settings.windowsSavePath,
+			settings.useWindowsTemp,
+		);
+		const windowsLockFile = windowsFilePath + ".lock";
+
+		const windowsLockExists = await checkWindowsFileExists(windowsLockFile);
+		if (windowsLockExists) {
+			console.log("Found Studio lockfile in Windows temp, attempting to stop Studio...");
+
+			// Read process ID from Windows lockfile using PowerShell
+			const processId = await readProcessIdFromWindowsLockfile(windowsLockFile);
+			if (processId) {
+				console.log(`Found lockfile with process ID ${processId}, stopping Studio...`);
+				try {
+					await terminateStudioProcess(processId);
+					console.log("Studio process terminated.");
+					// Clean up Windows lockfile after successful termination
+					await cleanupWindowsLockfile(windowsLockFile);
+					return true;
+				} catch (error) {
+					// Process might already be terminated, clean up stale lockfile
+					const errorMessage = error instanceof Error ? error.message : String(error);
+					if (errorMessage.includes("not found") || errorMessage.includes("128")) {
+						console.log("Process already terminated, cleaning up stale lockfile...");
+						await cleanupWindowsLockfile(windowsLockFile);
+						return true;
+					}
+					throw error; // Re-throw unexpected errors
+				}
+			} else {
+				console.warn("Windows lockfile exists but contains no valid process ID");
+				// Clean up invalid lockfile
+				await cleanupWindowsLockfile(windowsLockFile);
+			}
+		}
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.warn(`Could not check Windows temp lockfile: ${errorMessage}`);
+	}
+
+	return false;
+}
+
+/**
+ * Attempts to stop Studio using local lockfile
+ * @param projectPath - The project directory path
+ * @returns true if Studio was stopped, false if no lockfile found
+ */
+async function tryStopLocalStudio(projectPath: string): Promise<boolean> {
 	const lockFilePath = path.join(projectPath, LOCKFILE_NAME);
 
-	try {
-		const lockFileContents = (await fs.readFile(lockFilePath)).toString();
-		const processId = lockFileContents.split("\n")[0];
+	const processId = await readProcessIdFromLockfile(lockFilePath);
+	if (processId) {
+		console.log(`Found lockfile with process ID ${processId}, stopping Studio...`);
+		await terminateStudioProcess(processId);
+		console.log("Studio process terminated.");
+		return true;
+	}
 
-		await runPlatform({
-			darwin: () => run("kill", ["-9", processId]),
-			linux: () => run("taskkill.exe", ["/f", "/pid", processId]),
-			win32: () => run("taskkill", ["/f", "/pid", processId]),
-		});
-	} catch {}
+	return false;
+}
 
-	try {
-		await fs.rm(lockFilePath);
-	} catch {}
+/**
+ * Main handler for the stop command
+ */
+async function handler(): Promise<void> {
+	const projectPath = process.cwd();
+	const settings = await getSettings(projectPath);
+
+	// Try Windows temp lockfile first if enabled
+	const stoppedFromWindows = await tryStopWindowsTempStudio(projectPath, settings);
+	if (stoppedFromWindows) {
+		return;
+	}
+
+	// Remove local lockfile if it exists
+	const stoppedFromLocal = await tryStopLocalStudio(projectPath);
+	if (!stoppedFromLocal) {
+		console.log("No Studio lockfile found or Studio not running.");
+	}
+
+	// Clean up lockfile regardless of success
+	await cleanupLockfile(projectPath);
 }
 
 export = identity<yargs.CommandModule>({ command, handler });

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,8 +1,18 @@
+import path from "path";
 import yargs from "yargs";
+import { PLACEFILE_NAME, WSL_SYNC_POLL_INTERVAL } from "../constants";
 import { getSettings } from "../util/getSettings";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
 import { platform } from "../util/runPlatform";
+import {
+	shouldUseWindowsTemp,
+	getWindowsSafePath,
+	syncFromWindows,
+	isWindowsFileNewer,
+	checkWindowsFileExists,
+	waitForWindowsFile,
+} from "../util/wslFileSync";
 
 const command = "watch";
 
@@ -14,6 +24,92 @@ async function handler() {
 	const rbxtsc = settings.dev ? "rbxtsc-dev" : "rbxtsc";
 	run(rojo, ["serve"]).catch(console.warn);
 	run(rbxtsc, ["-w"].concat(settings.rbxtscArgs ?? [])).catch(console.warn);
+
+	// For WSL users, start monitoring the Windows file for changes
+	if (shouldUseWindowsTemp(settings)) {
+		await startWindowsFileWatcher(projectPath, settings);
+	}
+}
+
+/**
+ * Start monitoring the Windows-accessible file for changes and sync back to WSL
+ */
+async function startWindowsFileWatcher(
+	projectPath: string,
+	settings: { windowsSavePath?: string; useWindowsTemp?: boolean },
+) {
+	try {
+		const wslFilePath = path.join(projectPath, PLACEFILE_NAME);
+		const windowsFilePath = await getWindowsSafePath(
+			wslFilePath,
+			settings.windowsSavePath,
+			settings.useWindowsTemp,
+		);
+
+		console.log(`Monitoring Windows file for Studio changes: ${windowsFilePath}`);
+
+		// Track the lockfile path
+		const windowsLockFile = windowsFilePath + ".lock";
+
+		// Wait for Studio to create the lockfile (up to 60 seconds)
+		console.log(`Waiting for Studio to open (checking for lockfile)...`);
+		const lockFileExists = await waitForWindowsFile(windowsLockFile, 60000);
+
+		if (!lockFileExists) {
+			console.warn("Timeout: Studio lockfile not detected after 60 seconds.");
+			console.warn("Studio may not have opened properly. Running stop command to clean up...");
+
+			// Try to stop any Studio processes that might be stuck
+			try {
+				await run("npm", ["run", "stop", "--silent"]);
+			} catch (error) {
+				console.warn("Could not run stop command:", error instanceof Error ? error.message : String(error));
+			}
+
+			console.warn("Please try opening Studio again.");
+			return;
+		}
+
+		console.log("Studio lockfile detected! Starting sync monitoring...");
+
+		// Poll for changes from Studio saves
+		const pollInterval = setInterval(async () => {
+			try {
+				// Check if Studio is still open by checking lockfile existence
+				const isStudioOpen = await checkWindowsFileExists(windowsLockFile);
+				if (!isStudioOpen) {
+					console.log("Studio closed, stopping sync...");
+					clearInterval(pollInterval);
+					return;
+				}
+
+				const isNewer = await isWindowsFileNewer(wslFilePath, windowsFilePath);
+				if (isNewer) {
+					console.log("Studio save detected, syncing back to WSL...");
+					await syncFromWindows(wslFilePath, windowsFilePath);
+					console.log("File synced successfully");
+				}
+			} catch (error) {
+				// Only log unexpected errors
+				if (error instanceof Error && !error.message.includes("does not exist")) {
+					console.warn(`Sync error: ${error.message}`);
+				}
+			}
+		}, WSL_SYNC_POLL_INTERVAL);
+
+		// Clean up on process exit
+		process.on("SIGINT", () => {
+			clearInterval(pollInterval);
+			process.exit(0);
+		});
+
+		process.on("SIGTERM", () => {
+			clearInterval(pollInterval);
+			process.exit(0);
+		});
+	} catch (error) {
+		console.warn(`Failed to start file monitor: ${error instanceof Error ? error.message : String(error)}`);
+	}
 }
 
 export = identity<yargs.CommandModule>({ command, handler });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,5 @@ export const LOCKFILE_NAME = PLACEFILE_NAME + ".lock";
 export const SYNC_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "sync.luau");
 export const MODEL_IMPORT_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "model_import.luau");
 export const MODEL_EXPORT_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "model_export.luau");
+
+export const WSL_SYNC_POLL_INTERVAL = 2000; // 2 seconds

--- a/src/typeChecks.ts
+++ b/src/typeChecks.ts
@@ -5,15 +5,19 @@ export const SCRIPT_NAMES = ["compile", "build", "open", "start", "stop", "sync"
 export const packageJsonType = z.object({
 	"rbxts-build": z
 		.object({
+			dev: z.boolean().optional(),
+			names: z.object(Object.fromEntries(SCRIPT_NAMES.map(name => [name, z.string().optional()]))).optional(),
 			rbxtscArgs: z.array(z.string()).optional(),
 			rojoBuildArgs: z.array(z.string()).optional(),
 			syncLocation: z.string().optional(),
-			wslUseExe: z.boolean().optional(),
-			dev: z.boolean().optional(),
+			useWindowsTemp: z.boolean().optional().default(false),
 			watchOnOpen: z.boolean().optional(),
-			names: z.object(Object.fromEntries(SCRIPT_NAMES.map(name => [name, z.string().optional()]))).optional(),
+			windowsSavePath: z.string().optional(),
+			wslUseExe: z.boolean().optional(),
 		})
 		.optional(),
 });
 
 export type packageJsonType = z.infer<typeof packageJsonType>;
+
+export type RbxtsBuildSettings = NonNullable<packageJsonType["rbxts-build"]>;

--- a/src/util/getSettings.ts
+++ b/src/util/getSettings.ts
@@ -1,10 +1,12 @@
-import { packageJsonType } from "../typeChecks";
+import { packageJsonType, RbxtsBuildSettings } from "../typeChecks";
 import fs from "fs/promises";
 import path from "path";
 
-export async function getSettings(projectPath: string) {
+export async function getSettings(projectPath: string): Promise<RbxtsBuildSettings> {
 	const pkgJsonPath = path.join(projectPath, "package.json");
 	const pkgJsonContents = (await fs.readFile(pkgJsonPath)).toString();
 	const pkgJson = packageJsonType.parse(JSON.parse(pkgJsonContents));
-	return pkgJson?.["rbxts-build"] ?? {};
+	// Apply default values by parsing with the schema
+	const defaultSettings = { "rbxts-build": pkgJson?.["rbxts-build"] ?? {} };
+	return packageJsonType.parse(defaultSettings)["rbxts-build"]!;
 }

--- a/src/util/pathSecurity.ts
+++ b/src/util/pathSecurity.ts
@@ -1,0 +1,39 @@
+/**
+ * Validate Windows path for security issues
+ */
+export function validateWindowsPath(inputPath: string): void {
+	if (!inputPath || typeof inputPath !== "string") {
+		throw new Error("Path must be a non-empty string");
+	}
+
+	// Check for path traversal attempts
+	if (inputPath.includes("..") || inputPath.includes("../") || inputPath.includes("..\\")) {
+		throw new Error("Path traversal not allowed");
+	}
+
+	// Check for forbidden characters that could break PowerShell
+	const forbiddenChars = ["'", "`", "$", ";", "&", "|", "<", ">", "(", ")", "{", "}", "[", "]"];
+	for (const char of forbiddenChars) {
+		if (inputPath.includes(char)) {
+			throw new Error(`Invalid character '${char}' in path`);
+		}
+	}
+
+	// Check length limits
+	if (inputPath.length > 260) {
+		throw new Error("Path exceeds maximum Windows path length");
+	}
+
+	// Ensure it looks like a valid Windows path
+	if (!inputPath.match(/^[a-zA-Z]:[\\w\s.-]*$/) && !inputPath.match(/^\\\\[\w.-]+\\[\w\s.-]*$/)) {
+		throw new Error("Invalid Windows path format");
+	}
+}
+
+/**
+ * Escape PowerShell special characters in paths
+ */
+export function escapePowerShellPath(inputPath: string): string {
+	// Replace single quotes with double quotes for PowerShell safety
+	return inputPath.replace(/'/g, "''");
+}

--- a/src/util/studioProcess.ts
+++ b/src/util/studioProcess.ts
@@ -1,0 +1,96 @@
+import fs from "fs/promises";
+import path from "path";
+import { LOCKFILE_NAME } from "../constants";
+import { cmd } from "./cmd";
+import { escapePowerShellPath } from "./pathSecurity";
+import { run } from "./run";
+import { runPlatform } from "./runPlatform";
+
+/**
+ * Reads process ID from a Windows lockfile using PowerShell
+ * @param windowsLockFilePath - Windows path to the lockfile
+ * @returns Process ID if found, null otherwise
+ */
+export async function readProcessIdFromWindowsLockfile(windowsLockFilePath: string): Promise<string | null> {
+	try {
+		const escapedPath = escapePowerShellPath(windowsLockFilePath);
+		const content = await cmd(`powershell.exe -Command "Get-Content -LiteralPath '${escapedPath}' -TotalCount 1"`);
+		const processId = content.trim();
+		return processId || null;
+	} catch (error) {
+		console.warn(
+			`Could not read Windows lockfile ${windowsLockFilePath}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return null;
+	}
+}
+
+/**
+ * Reads process ID from a local WSL lockfile
+ * @param lockFilePath - Path to the lockfile
+ * @returns Process ID if found, null otherwise
+ */
+export async function readProcessIdFromLockfile(lockFilePath: string): Promise<string | null> {
+	try {
+		const lockFileHandle = await fs.open(lockFilePath, "r");
+		try {
+			const buffer = Buffer.alloc(50); // Enough for a process ID
+			const { bytesRead } = await lockFileHandle.read(buffer, 0, 50, 0);
+			const content = buffer.subarray(0, bytesRead).toString();
+			const processId = content.split("\n")[0].trim();
+			return processId || null;
+		} finally {
+			await lockFileHandle.close();
+		}
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code !== "ENOENT") {
+			console.warn(`Unexpected error reading lockfile ${lockFilePath}: ${error.message}`);
+		}
+		return null;
+	}
+}
+
+/**
+ * Terminates Studio processes using platform-specific commands
+ * @param processId - The process ID to terminate
+ */
+export async function terminateStudioProcess(processId: string): Promise<void> {
+	await runPlatform({
+		darwin: () => run("kill", ["-9", processId]),
+		linux: () => run("taskkill.exe", ["/f", "/pid", processId]),
+		win32: () => run("taskkill", ["/f", "/pid", processId]),
+	});
+}
+
+/**
+ * Safely removes a Windows lockfile using PowerShell
+ * @param windowsLockFilePath - Windows path to the lockfile
+ */
+export async function cleanupWindowsLockfile(windowsLockFilePath: string): Promise<void> {
+	try {
+		const escapedPath = escapePowerShellPath(windowsLockFilePath);
+		await cmd(
+			`powershell.exe -Command "Remove-Item -LiteralPath '${escapedPath}' -Force -ErrorAction SilentlyContinue"`,
+		);
+	} catch (error) {
+		// Ignore cleanup errors - lockfile might already be gone
+	}
+}
+
+/**
+ * Safely removes the WSL lockfile with proper error handling
+ * @param projectPath - The project directory path
+ */
+export async function cleanupLockfile(projectPath: string): Promise<void> {
+	const lockFilePath = path.join(projectPath, LOCKFILE_NAME);
+
+	try {
+		await fs.rm(lockFilePath, { force: true });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code !== "ENOENT") {
+			console.warn(`Failed to clean up lockfile: ${error.message}`);
+		}
+	}
+}

--- a/src/util/wslFileSync.ts
+++ b/src/util/wslFileSync.ts
@@ -1,0 +1,219 @@
+import fs from "fs";
+import path from "path";
+import { cmd } from "./cmd";
+import { getWindowsPath } from "./getWindowsPath";
+import { platform } from "./runPlatform";
+import { validateWindowsPath, escapePowerShellPath } from "./pathSecurity";
+
+/**
+ * Check if we're running on WSL
+ */
+export function isWSL(): boolean {
+	return platform === "linux" && process.env.WSL_DISTRO_NAME !== undefined;
+}
+
+/**
+ * Check if WSL Windows temp workaround should be used
+ */
+export function shouldUseWindowsTemp(settings: { useWindowsTemp?: boolean }): boolean {
+	// Default to false, only enable if explicitly set to true
+	return isWSL() && settings.useWindowsTemp === true;
+}
+
+/**
+ * Get a Windows-accessible path for the given file
+ * For WSL: Returns path in Windows temp directory
+ * For other platforms: Returns original path
+ */
+export async function getWindowsSafePath(
+	filePath: string,
+	customWindowsPath?: string,
+	useWindowsTemp?: boolean,
+): Promise<string> {
+	if (!isWSL() || useWindowsTemp === false) {
+		return filePath;
+	}
+
+	const fileName = path.basename(filePath);
+
+	if (customWindowsPath) {
+		try {
+			// Validate custom Windows path before using
+			validateWindowsPath(customWindowsPath);
+			// Use custom Windows path if provided
+			const escapedPath = escapePowerShellPath(customWindowsPath);
+			const windowsCustomPath = await cmd(`wslpath -w "${escapedPath}"`);
+			return `${windowsCustomPath.trim()}\\${fileName}`;
+		} catch (error) {
+			throw new Error(
+				`Invalid Windows path configuration: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	}
+
+	// Use Windows temp directory - use PowerShell to get the temp path
+	const windowsTempDir = await cmd('powershell.exe -Command "[System.IO.Path]::GetTempPath()"');
+	const tempPath = windowsTempDir.trim();
+
+	// Create a subdirectory for rbxts-build files - use Windows path separators
+	const rbxtsBuildDir = `${tempPath}rbxts-build`;
+
+	return `${rbxtsBuildDir}\\${fileName}`;
+}
+
+/**
+ * Ensure the given file is accessible from Windows
+ * For WSL: Copies file to Windows-accessible location
+ * For other platforms: Does nothing
+ */
+export async function ensureWindowsAccessible(
+	filePath: string,
+	customWindowsPath?: string,
+	useWindowsTemp?: boolean,
+): Promise<string> {
+	if (!isWSL() || useWindowsTemp === false) {
+		return filePath;
+	}
+
+	const windowsPath = await getWindowsSafePath(filePath, customWindowsPath, useWindowsTemp);
+	const windowsDir = path.dirname(windowsPath);
+
+	// Create Windows directory if it doesn't exist using PowerShell
+	try {
+		const escapedWindowsDir = escapePowerShellPath(windowsDir);
+		await cmd(
+			`powershell.exe -Command "if (!(Test-Path -LiteralPath '${escapedWindowsDir}')) { New-Item -ItemType Directory -LiteralPath '${escapedWindowsDir}' -Force }"`,
+		);
+	} catch (error) {
+		const originalError = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to create Windows directory '${windowsDir}'. ` +
+				`This is required for Studio sync to work properly. ` +
+				`Error: ${originalError}`,
+		);
+	}
+
+	// Copy file to Windows location using PowerShell
+	try {
+		const wslSourcePath = await getWindowsPath(filePath);
+		const escapedSourcePath = escapePowerShellPath(wslSourcePath);
+		const escapedWindowsPath = escapePowerShellPath(windowsPath);
+		await cmd(
+			`powershell.exe -Command "Copy-Item -LiteralPath '${escapedSourcePath}' -Destination '${escapedWindowsPath}' -Force"`,
+		);
+	} catch (error) {
+		const originalError = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to copy file to Windows location. ` +
+				`Without this, Studio changes cannot be saved back to your project. ` +
+				`Error: ${originalError}`,
+		);
+	}
+
+	return windowsPath;
+}
+
+/**
+ * Sync file back from Windows location to WSL
+ * For WSL: Copies file from Windows location back to WSL
+ * For other platforms: Does nothing
+ */
+export async function syncFromWindows(wslPath: string, windowsPath: string): Promise<void> {
+	if (!isWSL()) {
+		return;
+	}
+
+	// Check if Windows file exists using PowerShell
+	const escapedCheckPath = escapePowerShellPath(windowsPath);
+	const windowsFileExists = await cmd(`powershell.exe -Command "Test-Path -LiteralPath '${escapedCheckPath}'"`)
+		.then(result => result.trim().toLowerCase() === "true")
+		.catch(() => false);
+
+	if (!windowsFileExists) {
+		throw new Error("Windows file does not exist or is not accessible");
+	}
+
+	// Copy from Windows back to WSL using PowerShell
+	try {
+		const wslTargetPath = await getWindowsPath(wslPath);
+		const escapedSyncWindowsPath = escapePowerShellPath(windowsPath);
+		const escapedWslTargetPath = escapePowerShellPath(wslTargetPath);
+		await cmd(
+			`powershell.exe -Command "Copy-Item -LiteralPath '${escapedSyncWindowsPath}' -Destination '${escapedWslTargetPath}' -Force"`,
+		);
+	} catch (error) {
+		throw new Error("Failed to sync file from Windows to WSL");
+	}
+}
+
+/**
+ * Check if Windows file is newer than WSL file
+ */
+export async function isWindowsFileNewer(wslPath: string, windowsPath: string): Promise<boolean> {
+	if (!isWSL()) {
+		return false;
+	}
+
+	try {
+		// Get WSL file stats
+		const wslStats = fs.existsSync(wslPath) ? fs.statSync(wslPath) : null;
+
+		// Get Windows file stats using PowerShell
+		const escapedStatsPath = escapePowerShellPath(windowsPath);
+		const windowsStatsCmd = `powershell.exe -Command "(Get-Item -LiteralPath '${escapedStatsPath}').LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss')"`;
+		const windowsDateStr = await cmd(windowsStatsCmd).catch(() => null);
+
+		if (!wslStats || !windowsDateStr) {
+			return windowsDateStr !== null; // If only Windows file exists, it's "newer"
+		}
+
+		// Parse Windows date/time using PowerShell formatted output
+		const windowsModified = new Date(windowsDateStr.trim());
+
+		return windowsModified > wslStats.mtime;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Check if a file exists in Windows using PowerShell
+ */
+export async function checkWindowsFileExists(windowsPath: string): Promise<boolean> {
+	try {
+		const escapedPath = escapePowerShellPath(windowsPath);
+		const result = await cmd(`powershell.exe -Command "Test-Path -LiteralPath '${escapedPath}'"`);
+		return result.trim().toLowerCase() === "true";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Wait for a Windows file to exist, with timeout
+ */
+export async function waitForWindowsFile(windowsPath: string, timeoutMs: number = 60000): Promise<boolean> {
+	const startTime = Date.now();
+	const checkInterval = 1000; // Check every 1 second
+	let lastProgressTime = 0;
+	const progressInterval = 10000; // Show progress every 10 seconds
+
+	while (Date.now() - startTime < timeoutMs) {
+		const exists = await checkWindowsFileExists(windowsPath);
+		if (exists) {
+			return true;
+		}
+
+		// Show progress every 10 seconds
+		const elapsed = Date.now() - startTime;
+		if (elapsed - lastProgressTime >= progressInterval) {
+			const remaining = Math.ceil((timeoutMs - elapsed) / 1000);
+			console.log(`Still waiting for Studio to open... (${remaining}s remaining)`);
+			lastProgressTime = elapsed;
+		}
+
+		await new Promise(resolve => setTimeout(resolve, checkInterval));
+	}
+
+	return false; // Timeout reached
+}


### PR DESCRIPTION
## 🎯 Problem
WSL users couldn't effectively use Roblox Studio with rbxts-build because:
- Studio can't save files directly to WSL filesystem
- No automatic sync between WSL project and Studio edits
- Manual copying required for every edit cycle

## ✨ Solution
Implements automatic bi-directional file synchronization:

**WSL → Windows**: When opening projects, copies `game.rbxl` to Windows-accessible location
**Windows → WSL**: Monitors Studio saves and syncs changes back to WSL project

## 🔧 Key Features

### New Configuration Options
```json
{
  "rbxts-build": {
    "useWindowsTemp": true,           // Enable Windows temp directory sync
    "windowsSavePath": "C:\\Projects" // Optional: custom Windows directory
  }
}
```

Intelligent Monitoring

- ✅ Studio detection: Waits for Studio lockfile before starting sync
- ✅ Auto-termination: Stops monitoring when Studio closes
- ✅ Timeout handling: Cleanup if Studio doesn't open within 60s

🔄 Workflow

1. npm run build    → Creates game.rbxl in WSL
2. npm run open     → Copies to Windows temp + Opens Studio
3. Edit in Studio   → Saves to Windows temp file
4. Auto-sync        → Copies changes back to WSL project
5. Studio closes    → Monitoring stops automatically

Enhanced Commands

- open: Now handles Windows copying and file validation
- watch: Monitors Windows temp files with Studio lockfile detection
- stop: Enhanced to work with Windows temp files and process cleanup

🧪 Testing Notes

Tested on WSL2 with Windows 11:
- ✅ File copying to Windows temp directory
- ✅ Studio lockfile detection and monitoring
- ✅ Bi-directional sync during edit sessions
- ✅ Automatic cleanup on Studio close
- ✅ Timeout handling for stuck processes

🚨 Breaking Changes

None - all new functionality is opt-in via configuration.
