### PR TITLE
feat: implement syncback command with continuous monitoring

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,7 @@
 		"@typescript-eslint/explicit-function-return-type": "off",
 		"@typescript-eslint/interface-name-prefix": "off",
 		"@typescript-eslint/no-empty-function": "off",
-		"@typescript-eslint/no-empty-interface": "Off",
+		"@typescript-eslint/no-empty-interface": "off",
 		"@typescript-eslint/no-namespace": "off",
 		"@typescript-eslint/no-non-null-assertion": "off",
 		"@typescript-eslint/no-use-before-define": "off",

--- a/.luaurc
+++ b/.luaurc
@@ -1,0 +1,5 @@
+{
+  "aliases": {
+    "lune": "~/.lune/.typedefs/0.9.4/"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+rbxts-build is an opinionated build orchestrator for roblox-ts projects. It's a CLI tool that manages the build process for Roblox TypeScript projects, including compilation, building, and syncing with Roblox Studio.
+
+## Development Commands
+
+### Building the Project
+```bash
+npm run build        # Compile TypeScript to JavaScript
+npm run build-watch  # Watch mode for TypeScript compilation
+```
+
+### Testing/Development
+```bash
+npm run devlink     # Link the package locally for testing
+```
+
+## Architecture
+
+### Core Structure
+
+- **Commands** (`src/commands/`): Each file represents a CLI command (build, compile, open, start, stop, sync, watch, init, modeledit)
+- **Utilities** (`src/util/`): Helper functions for command execution, platform detection, and settings management
+- **Type System** (`src/typeChecks.ts`): Zod schemas for validating configuration
+- **Entry Point** (`src/index.ts`): CLI setup using yargs
+
+### Key Components
+
+1. **Settings System**: Reads configuration from `package.json` under the `"rbxts-build"` key
+2. **Command Execution**: Uses child process spawning to run external tools (rbxtsc, rojo, lune)
+3. **Platform Detection**: Handles Windows/WSL-specific behavior for executables
+
+### Available Settings
+
+Settings are configured in the consuming project's `package.json`:
+```json
+{
+  "rbxts-build": {
+    "rbxtscArgs": ["--verbose"],
+    "rojoBuildArgs": ["--output", "game.rbxl"],
+    "syncLocation": "src/services.d.ts",
+    "dev": false,
+    "wslUseExe": false,
+    "watchOnOpen": true,
+    "names": {
+      "build": "custom-build-name"
+    }
+  }
+}
+```
+
+## Code Conventions
+
+- **TypeScript**: Strict mode enabled, ES2019 target
+- **Formatting**: Uses Prettier with tabs, 120 character line width, trailing commas
+- **Linting**: ESLint with TypeScript plugin
+- **Module Pattern**: CommonJS modules with default exports for command modules
+- **Error Handling**: Custom CLIError class for user-facing errors
+
+## External Dependencies
+
+- **yargs**: CLI argument parsing and command routing
+- **kleur**: Terminal color output
+- **zod**: Runtime type validation for configuration
+
+## Important Notes
+
+- All commands assume the project is a Roblox game fully managed by Rojo
+- Scripts are executed from the project directory (where package.json lives)
+- The tool integrates with rbxtsc (roblox-ts compiler), rojo (project sync), and lune (Luau runtime)

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,0 +1,7 @@
+# This file lists tools managed by Rokit, a toolchain manager for Roblox projects.
+# For more information, see https://github.com/rojo-rbx/rokit
+
+# New tools can be added by running `rokit add <tool>` in a terminal.
+
+[tools]
+lune = "lune-org/lune@0.9.4"

--- a/scripts/syncback.luau
+++ b/scripts/syncback.luau
@@ -1,0 +1,61 @@
+--[[
+	Syncback script for rbxts-build
+	Continuous monitoring for syncback functionality
+]]
+
+local process = require("@lune/process")
+local fs = require("@lune/fs")
+local task = require("@lune/task")
+
+local mode = process.args[1] or "single"
+local placeFile = process.args[2] or "game.rbxl"
+local projectFile = process.args[3] or "default.project.json"
+
+if mode == "single" then
+	-- Single syncback operation
+	print("Running syncback...")
+	local result = process.create("rojo", { "syncback", "--input", placeFile, "--non-interactive", projectFile })
+
+	if result.ok then
+		print("Syncback completed successfully")
+	else
+		print("Syncback failed (exit code: " .. tostring(result.code) .. ")")
+		process.exit(1)
+	end
+elseif mode == "watch" then
+	-- Continuous monitoring implementation
+	print("Starting continuous syncback monitoring...")
+	print("Press Ctrl+C to stop monitoring")
+
+	local lastModified = 0
+
+	-- Check if place file exists
+	if not fs.isFile(placeFile) then
+		print("Error: Place file " .. placeFile .. " not found")
+		process.exit(1)
+	end
+
+	while true do
+		local metadata = fs.metadata(placeFile)
+		if metadata.modifiedAt and metadata.modifiedAt.unixTimestampMillis > lastModified then
+			lastModified = metadata.modifiedAt.unixTimestampMillis
+
+			print(placeFile .. " changed. Running syncback...")
+
+			local result = process.exec("rojo", { "syncback", "--input", placeFile, "--non-interactive", projectFile })
+
+			if result.ok then
+				print("  syncback succeeded")
+			else
+				print("  syncback failed (exit code: " .. tostring(result.code) .. ")")
+			end
+		end
+
+		task.wait(1) -- Check every second
+	end
+else
+	print("Usage: lune run syncback.luau [single|watch] [place_file] [project_file]")
+	print("  single: Run syncback once (default)")
+	print("  watch: Monitor for changes and run syncback continuously")
+	process.exit(1)
+end

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -4,6 +4,7 @@ import { getSettings } from "../util/getSettings";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
 import { platform } from "../util/runPlatform";
+import { isWSL } from "../util/wslFileSync";
 
 const command = "build";
 
@@ -11,7 +12,7 @@ async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
 
-	const rojo = platform === "linux" && settings.wslUseExe ? "rojo.exe" : "rojo";
+	const rojo = isWSL() && settings.wslUseExe ? "rojo.exe" : "rojo";
 	await run(rojo, ["build", ...(settings.rojoBuildArgs ?? ["--output", PLACEFILE_NAME])]);
 }
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -9,6 +9,7 @@ import { identity } from "../util/identity";
 import { run } from "../util/run";
 import { runPlatform } from "../util/runPlatform";
 import { shouldUseWindowsTemp, ensureWindowsAccessible } from "../util/wslFileSync";
+import { openWindowsFile } from "../util/windowsFileOps";
 
 const command = "open";
 
@@ -40,11 +41,12 @@ async function handler() {
 					settings.useWindowsTemp,
 				);
 				console.log(`File copied to Windows-accessible location: ${windowsPath}`);
-				return run("cmd.exe", ["/c", `start "" "${windowsPath}"`]);
+				await openWindowsFile(windowsPath);
+				return;
 			}
 
 			const fsPath = await getWindowsPath(placeFilePath);
-			return run("cmd.exe", ["/c", `start "" "${fsPath}"`]);
+			await openWindowsFile(fsPath);
 		},
 		win32: () => {
 			assertFileExists(PLACEFILE_NAME);

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import yargs from "yargs";
 import { PLACEFILE_NAME } from "../constants";
@@ -7,20 +8,48 @@ import { getWindowsPath } from "../util/getWindowsPath";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
 import { runPlatform } from "../util/runPlatform";
+import { shouldUseWindowsTemp, ensureWindowsAccessible } from "../util/wslFileSync";
 
 const command = "open";
+
+function assertFileExists(filePath: string) {
+	if (!fs.existsSync(filePath)) {
+		throw new Error(`File '${PLACEFILE_NAME}' does not exist. Run 'build' first to create the file.`);
+	}
+}
 
 async function handler() {
 	const projectPath = process.cwd();
 	const settings = await getSettings(projectPath);
 
 	await runPlatform({
-		darwin: () => run("open", [PLACEFILE_NAME]),
-		linux: async () => {
-			const fsPath = await getWindowsPath(path.join(projectPath, PLACEFILE_NAME));
-			return run("powershell.exe", ["/c", `start ${fsPath}`]);
+		darwin: () => {
+			assertFileExists(PLACEFILE_NAME);
+			return run("open", [PLACEFILE_NAME]);
 		},
-		win32: () => run("start", [PLACEFILE_NAME]),
+		linux: async () => {
+			const placeFilePath = path.join(projectPath, PLACEFILE_NAME);
+			assertFileExists(placeFilePath);
+
+			if (shouldUseWindowsTemp(settings)) {
+				// Copy to Windows temp location first - this is currently
+				// required for sync to work
+				const windowsPath = await ensureWindowsAccessible(
+					placeFilePath,
+					settings.windowsSavePath,
+					settings.useWindowsTemp,
+				);
+				console.log(`File copied to Windows-accessible location: ${windowsPath}`);
+				return run("cmd.exe", ["/c", `start "" "${windowsPath}"`]);
+			}
+
+			const fsPath = await getWindowsPath(placeFilePath);
+			return run("cmd.exe", ["/c", `start "" "${fsPath}"`]);
+		},
+		win32: () => {
+			assertFileExists(PLACEFILE_NAME);
+			return run("start", [PLACEFILE_NAME]);
+		},
 	});
 
 	if (settings.watchOnOpen !== false) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -12,6 +12,12 @@ async function handler() {
 
 	await run("npm", ["run", getCommandName(settings, "compile"), "--silent"]);
 	await run("npm", ["run", getCommandName(settings, "build"), "--silent"]);
+
+	// Start syncback in parallel if enabled
+	if (settings.syncback) {
+		run("rbxts-build", ["syncback", "--watch", "--wait-for-studio"]).catch(console.warn);
+	}
+
 	await run("npm", ["run", getCommandName(settings, "open"), "--silent"]);
 }
 

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,32 +1,118 @@
-import fs from "fs/promises";
 import path from "path";
 import yargs from "yargs";
-import { LOCKFILE_NAME } from "../constants";
+import { LOCKFILE_NAME, PLACEFILE_NAME } from "../constants";
+import { RbxtsBuildSettings } from "../typeChecks";
+import { getSettings } from "../util/getSettings";
 import { identity } from "../util/identity";
-import { run } from "../util/run";
-import { runPlatform } from "../util/runPlatform";
+import {
+	readProcessIdFromWindowsLockfile,
+	readProcessIdFromLockfile,
+	terminateStudioProcess,
+	cleanupWindowsLockfile,
+	cleanupLockfile,
+} from "../util/studioProcess";
+import { shouldUseWindowsTemp, getWindowsSafePath, checkWindowsFileExists } from "../util/wslFileSync";
 
 const command = "stop";
 
-async function handler() {
-	const projectPath = process.cwd();
+/**
+ * Attempts to stop Studio using Windows temp lockfile
+ * @param projectPath - The project directory path
+ * @param settings - Project settings
+ * @returns true if Studio was stopped, false if no lockfile found
+ */
+async function tryStopWindowsTempStudio(projectPath: string, settings: RbxtsBuildSettings): Promise<boolean> {
+	if (!shouldUseWindowsTemp(settings)) {
+		return false;
+	}
 
+	try {
+		const placeFilePath = path.join(projectPath, PLACEFILE_NAME);
+		const windowsFilePath = await getWindowsSafePath(
+			placeFilePath,
+			settings.windowsSavePath,
+			settings.useWindowsTemp,
+		);
+		const windowsLockFile = windowsFilePath + ".lock";
+
+		const windowsLockExists = await checkWindowsFileExists(windowsLockFile);
+		if (windowsLockExists) {
+			console.log("Found Studio lockfile in Windows temp, attempting to stop Studio...");
+
+			// Read process ID from Windows lockfile using PowerShell
+			const processId = await readProcessIdFromWindowsLockfile(windowsLockFile);
+			if (processId) {
+				console.log(`Found lockfile with process ID ${processId}, stopping Studio...`);
+				try {
+					await terminateStudioProcess(processId);
+					console.log("Studio process terminated.");
+					// Clean up Windows lockfile after successful termination
+					await cleanupWindowsLockfile(windowsLockFile);
+					return true;
+				} catch (error) {
+					// Process might already be terminated, clean up stale lockfile
+					const errorMessage = error instanceof Error ? error.message : String(error);
+					if (errorMessage.includes("not found") || errorMessage.includes("128")) {
+						console.log("Process already terminated, cleaning up stale lockfile...");
+						await cleanupWindowsLockfile(windowsLockFile);
+						return true;
+					}
+					throw error; // Re-throw unexpected errors
+				}
+			} else {
+				console.warn("Windows lockfile exists but contains no valid process ID");
+				// Clean up invalid lockfile
+				await cleanupWindowsLockfile(windowsLockFile);
+			}
+		}
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.warn(`Could not check Windows temp lockfile: ${errorMessage}`);
+	}
+
+	return false;
+}
+
+/**
+ * Attempts to stop Studio using local lockfile
+ * @param projectPath - The project directory path
+ * @returns true if Studio was stopped, false if no lockfile found
+ */
+async function tryStopLocalStudio(projectPath: string): Promise<boolean> {
 	const lockFilePath = path.join(projectPath, LOCKFILE_NAME);
 
-	try {
-		const lockFileContents = (await fs.readFile(lockFilePath)).toString();
-		const processId = lockFileContents.split("\n")[0];
+	const processId = await readProcessIdFromLockfile(lockFilePath);
+	if (processId) {
+		console.log(`Found lockfile with process ID ${processId}, stopping Studio...`);
+		await terminateStudioProcess(processId);
+		console.log("Studio process terminated.");
+		return true;
+	}
 
-		await runPlatform({
-			darwin: () => run("kill", ["-9", processId]),
-			linux: () => run("taskkill.exe", ["/f", "/pid", processId]),
-			win32: () => run("taskkill", ["/f", "/pid", processId]),
-		});
-	} catch {}
+	return false;
+}
 
-	try {
-		await fs.rm(lockFilePath);
-	} catch {}
+/**
+ * Main handler for the stop command
+ */
+async function handler(): Promise<void> {
+	const projectPath = process.cwd();
+	const settings = await getSettings(projectPath);
+
+	// Try Windows temp lockfile first if enabled
+	const stoppedFromWindows = await tryStopWindowsTempStudio(projectPath, settings);
+	if (stoppedFromWindows) {
+		return;
+	}
+
+	// Remove local lockfile if it exists
+	const stoppedFromLocal = await tryStopLocalStudio(projectPath);
+	if (!stoppedFromLocal) {
+		console.log("No Studio lockfile found or Studio not running.");
+	}
+
+	// Clean up lockfile regardless of success
+	await cleanupLockfile(projectPath);
 }
 
 export = identity<yargs.CommandModule>({ command, handler });

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,6 +6,7 @@ import { getWindowsPath } from "../util/getWindowsPath";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
 import { platform } from "../util/runPlatform";
+import { isWSL } from "../util/wslFileSync";
 
 const command = "sync";
 
@@ -17,7 +18,7 @@ async function handler() {
 
 	const outPath = settings.syncLocation ?? "src/services.d.ts";
 
-	if (platform === "linux" && settings.wslUseExe) {
+	if (isWSL() && settings.wslUseExe) {
 		const syncScriptPath = await getWindowsPath(SYNC_SCRIPT_PATH);
 		await run("lune.exe", ["run", syncScriptPath, PLACEFILE_NAME, outPath]);
 	} else {

--- a/src/commands/syncback.ts
+++ b/src/commands/syncback.ts
@@ -1,0 +1,149 @@
+import path from "path";
+import yargs from "yargs";
+import { DEFAULT_STUDIO_WAIT_TIMEOUT, PLACEFILE_NAME, SYNCBACK_SCRIPT_PATH } from "../constants";
+import { CLIError } from "../errors/CLIError";
+import { getSettings } from "../util/getSettings";
+import { identity } from "../util/identity";
+import { run } from "../util/run";
+import { checkRojoSyncback } from "../util/checkRojoSyncback";
+import { getWindowsPath } from "../util/getWindowsPath";
+import { waitForStudio } from "../util/waitForStudio";
+import { shouldUseWindowsTemp, getLockFilePath, isWSL } from "../util/wslFileSync";
+import { cmd } from "../util/cmd";
+import { setupSignalHandlers } from "../util/processManager";
+import fs from "fs";
+
+const command = "syncback";
+
+async function validateDependencies(settings: { wslUseExe?: boolean }): Promise<void> {
+	const isUsingWSL = isWSL() && settings.wslUseExe;
+	const luneCommand = isUsingWSL ? "lune.exe" : "lune";
+
+	// Check if Lune is available and has correct version
+	try {
+		const result = await cmd(`${luneCommand} --version`);
+		const versionMatch = result.match(/lune (\d+)\.(\d+)\.(\d+)/);
+
+		if (!versionMatch) {
+			throw new CLIError(`Unable to parse Lune version from: ${result.trim()}\n` + `Expected format: lune x.y.z`);
+		}
+
+		const [, major, minor] = versionMatch.map(Number);
+		const version = `${major}.${minor}`;
+
+		if (major < 0 || (major === 0 && minor < 9)) {
+			throw new CLIError(
+				`Lune version ${version} is not supported. Syncback requires Lune v0.9.0 or later.\n\n` +
+					`Current version: v${version}\n` +
+					`Required version: v0.9.0+\n\n` +
+					`Update Lune:\n` +
+					`• Visit: https://github.com/lune-org/lune/releases\n` +
+					`• Or install via: cargo install lune`,
+			);
+		}
+	} catch (error) {
+		if (error instanceof CLIError) {
+			throw error;
+		}
+
+		let message = `Missing required dependency: lune\n\n`;
+		message += `Syncback requires the following tools:\n`;
+		message += `• Rojo (for syncback functionality)\n`;
+		message += `• Lune (for continuous monitoring)\n\n`;
+		message += `To install lune:\n`;
+		message += `• Visit: https://github.com/lune-org/lune/releases\n`;
+		message += `• Required version: v0.9.0 or later`;
+
+		if (isWSL()) {
+			message += `\n\nFor WSL users: You may need to install the .exe versions or configure wslUseExe in settings.`;
+		}
+
+		throw new CLIError(message);
+	}
+}
+
+async function validateProjectFiles(projectPath: string): Promise<void> {
+	const placeFilePath = path.join(projectPath, PLACEFILE_NAME);
+	const projectFilePath = path.join(projectPath, "default.project.json");
+
+	if (!fs.existsSync(projectFilePath)) {
+		throw new CLIError(
+			`Project file not found: ${projectFilePath}\n` +
+				`Syncback requires a Rojo project file to determine sync targets.`,
+		);
+	}
+
+	if (!fs.existsSync(placeFilePath)) {
+		console.warn(
+			`Warning: Place file not found: ${placeFilePath}\n` + `Syncback will monitor for this file to be created.`,
+		);
+	}
+}
+
+async function handler(argv: yargs.ArgumentsCamelCase<SyncbackCommandArgs>): Promise<void> {
+	const projectPath = process.cwd();
+	const settings = await getSettings(projectPath);
+
+	// Validate all dependencies and project files
+	await Promise.all([checkRojoSyncback(), validateDependencies(settings), validateProjectFiles(projectPath)]);
+
+	// Wait for Studio to open only if requested
+	if (argv.waitForStudio) {
+		if (shouldUseWindowsTemp(settings)) {
+			// Get the correct lock file path based on where the file was opened
+			const placeFilePath = path.join(projectPath, PLACEFILE_NAME);
+			const lockFilePath = await getLockFilePath(
+				placeFilePath,
+				settings.windowsSavePath,
+				settings.useWindowsTemp,
+			);
+			await waitForStudio(DEFAULT_STUDIO_WAIT_TIMEOUT, lockFilePath);
+		} else {
+			// Use default behavior when Windows temp is disabled
+			await waitForStudio();
+		}
+	}
+
+	// Determine sync mode based on watch flag
+	const syncMode = argv.watch ? "watch" : "single";
+
+	if (syncMode === "watch") {
+		// Setup signal handlers for graceful shutdown during continuous monitoring
+		setupSignalHandlers();
+		console.log("Starting syncback monitoring...");
+	} else {
+		console.log("Performing single syncback...");
+	}
+
+	// Delegate to Lune script with appropriate mode
+	if (isWSL() && settings.wslUseExe) {
+		const syncScriptPath = await getWindowsPath(SYNCBACK_SCRIPT_PATH);
+		await run("lune.exe", ["run", syncScriptPath, syncMode, PLACEFILE_NAME, "default.project.json"]);
+	} else {
+		await run("lune", ["run", SYNCBACK_SCRIPT_PATH, syncMode, PLACEFILE_NAME, "default.project.json"]);
+	}
+}
+
+interface SyncbackCommandArgs {
+	waitForStudio: boolean;
+	watch: boolean;
+}
+
+export = identity<yargs.CommandModule<object, SyncbackCommandArgs>>({
+	command,
+	handler,
+	builder: (yargs): yargs.Argv<SyncbackCommandArgs> => {
+		return yargs
+			.option("waitForStudio", {
+				alias: "w",
+				type: "boolean",
+				description: "Wait for Roblox Studio to open before starting syncback",
+				default: false,
+			})
+			.option("watch", {
+				type: "boolean",
+				description: "Run in continuous monitoring mode (watch for changes)",
+				default: false,
+			});
+	},
+});

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,8 +1,18 @@
+import path from "path";
 import yargs from "yargs";
+import { PLACEFILE_NAME, WSL_SYNC_POLL_INTERVAL } from "../constants";
 import { getSettings } from "../util/getSettings";
 import { identity } from "../util/identity";
 import { run } from "../util/run";
 import { platform } from "../util/runPlatform";
+import {
+	shouldUseWindowsTemp,
+	getWindowsSafePath,
+	syncFromWindows,
+	isWindowsFileNewer,
+	checkWindowsFileExists,
+	waitForWindowsFile,
+} from "../util/wslFileSync";
 
 const command = "watch";
 
@@ -14,6 +24,92 @@ async function handler() {
 	const rbxtsc = settings.dev ? "rbxtsc-dev" : "rbxtsc";
 	run(rojo, ["serve"]).catch(console.warn);
 	run(rbxtsc, ["-w"].concat(settings.rbxtscArgs ?? [])).catch(console.warn);
+
+	// For WSL users, start monitoring the Windows file for changes
+	if (shouldUseWindowsTemp(settings)) {
+		await startWindowsFileWatcher(projectPath, settings);
+	}
+}
+
+/**
+ * Start monitoring the Windows-accessible file for changes and sync back to WSL
+ */
+async function startWindowsFileWatcher(
+	projectPath: string,
+	settings: { windowsSavePath?: string; useWindowsTemp?: boolean },
+) {
+	try {
+		const wslFilePath = path.join(projectPath, PLACEFILE_NAME);
+		const windowsFilePath = await getWindowsSafePath(
+			wslFilePath,
+			settings.windowsSavePath,
+			settings.useWindowsTemp,
+		);
+
+		console.log(`Monitoring Windows file for Studio changes: ${windowsFilePath}`);
+
+		// Track the lockfile path
+		const windowsLockFile = windowsFilePath + ".lock";
+
+		// Wait for Studio to create the lockfile (up to 60 seconds)
+		console.log(`Waiting for Studio to open (checking for lockfile)...`);
+		const lockFileExists = await waitForWindowsFile(windowsLockFile, 60000);
+
+		if (!lockFileExists) {
+			console.warn("Timeout: Studio lockfile not detected after 60 seconds.");
+			console.warn("Studio may not have opened properly. Running stop command to clean up...");
+
+			// Try to stop any Studio processes that might be stuck
+			try {
+				await run("npm", ["run", "stop", "--silent"]);
+			} catch (error) {
+				console.warn("Could not run stop command:", error instanceof Error ? error.message : String(error));
+			}
+
+			console.warn("Please try opening Studio again.");
+			return;
+		}
+
+		console.log("Studio lockfile detected! Starting sync monitoring...");
+
+		// Poll for changes from Studio saves
+		const pollInterval = setInterval(async () => {
+			try {
+				// Check if Studio is still open by checking lockfile existence
+				const isStudioOpen = await checkWindowsFileExists(windowsLockFile);
+				if (!isStudioOpen) {
+					console.log("Studio closed, stopping sync...");
+					clearInterval(pollInterval);
+					return;
+				}
+
+				const isNewer = await isWindowsFileNewer(wslFilePath, windowsFilePath);
+				if (isNewer) {
+					console.log("Studio save detected, syncing back to WSL...");
+					await syncFromWindows(wslFilePath, windowsFilePath);
+					console.log("File synced successfully");
+				}
+			} catch (error) {
+				// Only log unexpected errors
+				if (error instanceof Error && !error.message.includes("does not exist")) {
+					console.warn(`Sync error: ${error.message}`);
+				}
+			}
+		}, WSL_SYNC_POLL_INTERVAL);
+
+		// Clean up on process exit
+		process.on("SIGINT", () => {
+			clearInterval(pollInterval);
+			process.exit(0);
+		});
+
+		process.on("SIGTERM", () => {
+			clearInterval(pollInterval);
+			process.exit(0);
+		});
+	} catch (error) {
+		console.warn(`Failed to start file monitor: ${error instanceof Error ? error.message : String(error)}`);
+	}
 }
 
 export = identity<yargs.CommandModule>({ command, handler });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,11 @@ export const PLACEFILE_NAME = "game.rbxl";
 export const LOCKFILE_NAME = PLACEFILE_NAME + ".lock";
 
 export const SYNC_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "sync.luau");
+export const SYNCBACK_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "syncback.luau");
 export const MODEL_IMPORT_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "model_import.luau");
 export const MODEL_EXPORT_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "model_export.luau");
 
 export const WSL_SYNC_POLL_INTERVAL = 2000; // 2 seconds
+export const DEFAULT_STUDIO_WAIT_TIMEOUT = 60000; // 60 seconds
+export const WSL_PROGRESS_UPDATE_INTERVAL = 10000; // Show progress every 10 seconds
+export const WSL_RBXTS_BUILD_SUBDIR = "rbxts-build"; // Subdirectory name in Windows temp

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,5 @@ export const LOCKFILE_NAME = PLACEFILE_NAME + ".lock";
 export const SYNC_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "sync.luau");
 export const MODEL_IMPORT_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "model_import.luau");
 export const MODEL_EXPORT_SCRIPT_PATH = path.join(PACKAGE_ROOT, "scripts", "model_export.luau");
+
+export const WSL_SYNC_POLL_INTERVAL = 2000; // 2 seconds

--- a/src/typeChecks.ts
+++ b/src/typeChecks.ts
@@ -1,6 +1,7 @@
 import * as z from "zod";
+import { DEFAULT_STUDIO_WAIT_TIMEOUT } from "./constants";
 
-export const SCRIPT_NAMES = ["compile", "build", "open", "start", "stop", "sync", "watch"];
+export const SCRIPT_NAMES = ["build", "compile", "open", "start", "stop", "sync", "syncback", "watch"];
 
 export const packageJsonType = z.object({
 	"rbxts-build": z
@@ -10,6 +11,9 @@ export const packageJsonType = z.object({
 			rbxtscArgs: z.array(z.string()).optional(),
 			rojoBuildArgs: z.array(z.string()).optional(),
 			syncLocation: z.string().optional(),
+			studioWaitTimeout: z.number().min(1000).max(300000).optional().default(DEFAULT_STUDIO_WAIT_TIMEOUT),
+			syncback: z.boolean().optional(),
+			syncbackArgs: z.array(z.string()).optional(),
 			useWindowsTemp: z.boolean().optional().default(false),
 			watchOnOpen: z.boolean().optional(),
 			windowsSavePath: z.string().optional(),

--- a/src/typeChecks.ts
+++ b/src/typeChecks.ts
@@ -5,15 +5,19 @@ export const SCRIPT_NAMES = ["compile", "build", "open", "start", "stop", "sync"
 export const packageJsonType = z.object({
 	"rbxts-build": z
 		.object({
+			dev: z.boolean().optional(),
+			names: z.object(Object.fromEntries(SCRIPT_NAMES.map(name => [name, z.string().optional()]))).optional(),
 			rbxtscArgs: z.array(z.string()).optional(),
 			rojoBuildArgs: z.array(z.string()).optional(),
 			syncLocation: z.string().optional(),
-			wslUseExe: z.boolean().optional(),
-			dev: z.boolean().optional(),
+			useWindowsTemp: z.boolean().optional().default(false),
 			watchOnOpen: z.boolean().optional(),
-			names: z.object(Object.fromEntries(SCRIPT_NAMES.map(name => [name, z.string().optional()]))).optional(),
+			windowsSavePath: z.string().optional(),
+			wslUseExe: z.boolean().optional(),
 		})
 		.optional(),
 });
 
 export type packageJsonType = z.infer<typeof packageJsonType>;
+
+export type RbxtsBuildSettings = NonNullable<packageJsonType["rbxts-build"]>;

--- a/src/util/checkRojoSyncback.ts
+++ b/src/util/checkRojoSyncback.ts
@@ -1,0 +1,65 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { CLIError } from "../errors/CLIError";
+import { getSettings } from "./getSettings";
+import { isWSL } from "./wslFileSync";
+
+const execFileAsync = promisify(execFile);
+
+// Cache for Rojo validation results to avoid redundant process spawns
+const rojoValidationCache = new Map<string, boolean>();
+
+async function checkRojoCommand(rojoCommand: string): Promise<void> {
+	if (rojoValidationCache.has(rojoCommand)) {
+		if (!rojoValidationCache.get(rojoCommand)) {
+			throw new Error("Rojo syncback not supported (cached result)");
+		}
+		return;
+	}
+
+	try {
+		await execFileAsync(rojoCommand, ["syncback", "--help"], {
+			timeout: 5000,
+		});
+
+		rojoValidationCache.set(rojoCommand, true);
+	} catch (error) {
+		rojoValidationCache.set(rojoCommand, false);
+
+		if (error instanceof Error && "code" in error) {
+			if (error.code === "ENOENT") {
+				throw new Error(`Command '${rojoCommand}' not found`);
+			} else if (error.code === "TIMEOUT") {
+				throw new Error(`Command '${rojoCommand} syncback --help' timed out`);
+			} else if (typeof error.code === "number") {
+				throw new Error(`Command '${rojoCommand} syncback --help' exited with code ${error.code}`);
+			}
+		}
+
+		throw new Error(
+			`Failed to execute '${rojoCommand}': ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+export async function checkRojoSyncback(): Promise<void> {
+	const settings = await getSettings(process.cwd());
+	const rojo = isWSL() && settings.wslUseExe ? "rojo.exe" : "rojo";
+
+	try {
+		await checkRojoCommand(rojo);
+	} catch (error) {
+		let message = `Rojo syncback functionality is not available.\n\n`;
+		message += `Syncback requires the UpliftGames fork of Rojo with syncback support.\n\n`;
+		message += `Installation options:\n`;
+		message += `• Download from: https://github.com/UpliftGames/rojo/\n`;
+		message += `Note: Standard Rojo does not include syncback functionality.`;
+
+		if (error) {
+			const errorDetails = error instanceof Error ? error.message : String(error);
+			message += `\n\nError details: ${errorDetails}`;
+		}
+
+		throw new CLIError(message);
+	}
+}

--- a/src/util/cmd.ts
+++ b/src/util/cmd.ts
@@ -1,15 +1,24 @@
 import { exec, ExecException } from "child_process";
 import { CLIError } from "../errors/CLIError";
+import { processManager } from "./processManager";
 
-export function cmd(cmdStr: string) {
+export async function cmd(cmdStr: string, registerForCleanup: boolean = false): Promise<string> {
 	return new Promise<string>((resolve, reject) => {
-		exec(cmdStr, (error, stdout, stderr) => {
+		const childProcess = exec(cmdStr, (error, stdout) => {
 			if (error) {
-				reject(error);
+				const execError = error as ExecException;
+				reject(
+					new CLIError(
+						`Command "${execError.cmd}" exited with code ${execError.code}\n\n${execError.message}`,
+					),
+				);
+				return;
 			}
 			resolve(stdout);
 		});
-	}).catch((error: ExecException) => {
-		throw new CLIError(`Command "${error.cmd}" exited with code ${error.code}\n\n${error.message}`);
+
+		if (registerForCleanup) {
+			processManager.register(childProcess, `exec: ${cmdStr}`);
+		}
 	});
 }

--- a/src/util/getSettings.ts
+++ b/src/util/getSettings.ts
@@ -1,10 +1,12 @@
-import { packageJsonType } from "../typeChecks";
+import { packageJsonType, RbxtsBuildSettings } from "../typeChecks";
 import fs from "fs/promises";
 import path from "path";
 
-export async function getSettings(projectPath: string) {
+export async function getSettings(projectPath: string): Promise<RbxtsBuildSettings> {
 	const pkgJsonPath = path.join(projectPath, "package.json");
 	const pkgJsonContents = (await fs.readFile(pkgJsonPath)).toString();
 	const pkgJson = packageJsonType.parse(JSON.parse(pkgJsonContents));
-	return pkgJson?.["rbxts-build"] ?? {};
+	// Apply default values by parsing with the schema
+	const defaultSettings = { "rbxts-build": pkgJson?.["rbxts-build"] ?? {} };
+	return packageJsonType.parse(defaultSettings)["rbxts-build"]!;
 }

--- a/src/util/getWindowsPath.ts
+++ b/src/util/getWindowsPath.ts
@@ -1,5 +1,13 @@
 import { cmd } from "./cmd";
+import { pathCache } from "./operationCache";
 
-export async function getWindowsPath(fsPath: string) {
-	return (await cmd(`wslpath -w ${fsPath}`)).trim().replace(/\\/g, "\\\\").replace(/\//g, "\\");
+export async function getWindowsPath(fsPath: string): Promise<string> {
+	const cacheKey = `wsl-to-windows:${fsPath}`;
+	return await pathCache.getOrCompute(
+		cacheKey,
+		async () => {
+			return (await cmd(`wslpath -w ${fsPath}`)).trim().replace(/\\/g, "\\\\").replace(/\//g, "\\");
+		},
+		120000, // Cache for 2 minutes (paths are relatively stable)
+	);
 }

--- a/src/util/operationCache.ts
+++ b/src/util/operationCache.ts
@@ -1,0 +1,115 @@
+interface CacheEntry<T> {
+	value: T;
+	expires: number;
+}
+
+/**
+ * TTL-based cache for expensive operations
+ */
+export class OperationCache {
+	private cache = new Map<string, CacheEntry<unknown>>();
+
+	/**
+	 * Get a cached value or compute it if not found/expired
+	 */
+	public async getOrCompute<T>(key: string, fn: () => Promise<T>, ttlMs: number = 60000): Promise<T> {
+		const cached = this.cache.get(key);
+		if (cached && Date.now() < cached.expires) {
+			return cached.value as T;
+		}
+
+		const value = await fn();
+		this.cache.set(key, {
+			value,
+			expires: Date.now() + ttlMs,
+		});
+
+		return value;
+	}
+
+	/**
+	 * Get a cached value or compute it synchronously if not found/expired
+	 */
+	public getOrComputeSync<T>(key: string, fn: () => T, ttlMs: number = 60000): T {
+		const cached = this.cache.get(key);
+		if (cached && Date.now() < cached.expires) {
+			return cached.value as T;
+		}
+
+		const value = fn();
+		this.cache.set(key, {
+			value,
+			expires: Date.now() + ttlMs,
+		});
+
+		return value;
+	}
+
+	/**
+	 * Manually set a cache entry
+	 */
+	public set<T>(key: string, value: T, ttlMs: number = 60000): void {
+		this.cache.set(key, {
+			value,
+			expires: Date.now() + ttlMs,
+		});
+	}
+
+	/**
+	 * Check if a key exists and is not expired
+	 */
+	public has(key: string): boolean {
+		const cached = this.cache.get(key);
+		return cached ? Date.now() < cached.expires : false;
+	}
+
+	/**
+	 * Clear expired entries from the cache
+	 */
+	public cleanup(): void {
+		const now = Date.now();
+		for (const [key, entry] of this.cache.entries()) {
+			if (now >= entry.expires) {
+				this.cache.delete(key);
+			}
+		}
+	}
+
+	/**
+	 * Clear all cache entries
+	 */
+	public clear(): void {
+		this.cache.clear();
+	}
+
+	/**
+	 * Get cache statistics
+	 */
+	public getStats(): { size: number; expired: number } {
+		const now = Date.now();
+		let expired = 0;
+
+		for (const entry of this.cache.values()) {
+			if (now >= entry.expires) {
+				expired++;
+			}
+		}
+
+		return {
+			size: this.cache.size,
+			expired,
+		};
+	}
+}
+
+// Global cache instances for common operations
+export const pathCache = new OperationCache();
+export const tempPathCache = new OperationCache();
+export const fileMetadataCache = new OperationCache();
+
+// Manual cleanup function for short-lived commands
+export function cleanupAllCaches(): void {
+	pathCache.cleanup();
+	tempPathCache.cleanup();
+	fileMetadataCache.cleanup();
+}

--- a/src/util/pathSecurity.ts
+++ b/src/util/pathSecurity.ts
@@ -1,0 +1,39 @@
+/**
+ * Validate Windows path for security issues
+ */
+export function validateWindowsPath(inputPath: string): void {
+	if (!inputPath || typeof inputPath !== "string") {
+		throw new Error("Path must be a non-empty string");
+	}
+
+	// Check for path traversal attempts
+	if (inputPath.includes("..") || inputPath.includes("../") || inputPath.includes("..\\")) {
+		throw new Error("Path traversal not allowed");
+	}
+
+	// Check for forbidden characters that could break PowerShell
+	const forbiddenChars = ["'", "`", "$", ";", "&", "|", "<", ">", "(", ")", "{", "}", "[", "]"];
+	for (const char of forbiddenChars) {
+		if (inputPath.includes(char)) {
+			throw new Error(`Invalid character '${char}' in path`);
+		}
+	}
+
+	// Check length limits
+	if (inputPath.length > 260) {
+		throw new Error("Path exceeds maximum Windows path length");
+	}
+
+	// Ensure it looks like a valid Windows path
+	if (!inputPath.match(/^[a-zA-Z]:[\\w\s.-]*$/) && !inputPath.match(/^\\\\[\w.-]+\\[\w\s.-]*$/)) {
+		throw new Error("Invalid Windows path format");
+	}
+}
+
+/**
+ * Escape PowerShell special characters in paths
+ */
+export function escapePowerShellPath(inputPath: string): string {
+	// Replace single quotes with double quotes for PowerShell safety
+	return inputPath.replace(/'/g, "''");
+}

--- a/src/util/processManager.ts
+++ b/src/util/processManager.ts
@@ -1,0 +1,196 @@
+import { ChildProcess } from "child_process";
+
+interface RegisteredInterval {
+	id: NodeJS.Timeout;
+	description?: string;
+}
+
+/**
+ * Global process lifecycle manager for proper cleanup
+ */
+export class ProcessManager {
+	private processes = new Set<ChildProcess>();
+	private intervals = new Map<NodeJS.Timeout, RegisteredInterval>();
+	private isShuttingDown = false;
+	private cleanupPromise: Promise<void> | null = null;
+
+	/**
+	 * Register a child process for tracking and cleanup
+	 */
+	public register(process: ChildProcess, description?: string): void {
+		if (this.isShuttingDown) {
+			console.warn("ProcessManager is shutting down, cannot register new process");
+			return;
+		}
+
+		this.processes.add(process);
+
+		// Auto-remove when process exits
+		process.on("exit", () => {
+			this.processes.delete(process);
+		});
+
+		if (description) {
+			console.debug(`Registered process: ${description} (PID: ${process.pid})`);
+		}
+	}
+
+	/**
+	 * Register an interval for cleanup
+	 */
+	public registerInterval(interval: NodeJS.Timeout, description?: string): void {
+		if (this.isShuttingDown) {
+			console.warn("ProcessManager is shutting down, cannot register new interval");
+			clearInterval(interval);
+			return;
+		}
+
+		this.intervals.set(interval, { id: interval, description });
+
+		if (description) {
+			console.debug(`Registered interval: ${description}`);
+		}
+	}
+
+	/**
+	 * Unregister an interval (when manually cleared)
+	 */
+	public unregisterInterval(interval: NodeJS.Timeout): void {
+		this.intervals.delete(interval);
+	}
+
+	/**
+	 * Get current process and interval counts
+	 */
+	public getStats(): { processes: number; intervals: number } {
+		return {
+			processes: this.processes.size,
+			intervals: this.intervals.size,
+		};
+	}
+
+	/**
+	 * Cleanup all tracked resources
+	 */
+	async cleanup(): Promise<void> {
+		if (this.cleanupPromise) {
+			return this.cleanupPromise;
+		}
+
+		this.isShuttingDown = true;
+
+		this.cleanupPromise = this.performCleanup();
+		return this.cleanupPromise;
+	}
+
+	private async performCleanup(): Promise<void> {
+		console.log("ProcessManager: Starting cleanup...");
+
+		// Clear all intervals first
+		for (const [interval, info] of this.intervals.entries()) {
+			clearInterval(interval);
+			if (info.description) {
+				console.debug(`Cleared interval: ${info.description}`);
+			}
+		}
+
+		this.intervals.clear();
+
+		// Terminate all processes
+		const processCleanupPromises: Array<Promise<void>> = [];
+
+		for (const process of this.processes) {
+			if (process.killed || process.exitCode !== null) {
+				continue;
+			}
+
+			processCleanupPromises.push(this.terminateProcess(process));
+		}
+
+		// Wait for all processes to terminate (with timeout)
+		try {
+			await Promise.race([
+				Promise.all(processCleanupPromises),
+				new Promise(resolve => setTimeout(resolve, 5000)), // 5 second timeout
+			]);
+		} catch (error) {
+			console.warn("Some processes may not have terminated cleanly:", error);
+		}
+
+		this.processes.clear();
+		console.log("ProcessManager: Cleanup completed");
+	}
+
+	private async terminateProcess(process: ChildProcess): Promise<void> {
+		return new Promise<void>(resolve => {
+			if (process.killed || process.exitCode !== null) {
+				resolve();
+				return;
+			}
+
+			const timeout = setTimeout(() => {
+				if (!process.killed) {
+					console.warn(`Force killing process ${process.pid}`);
+					process.kill("SIGKILL");
+				}
+				resolve();
+			}, 3000);
+
+			process.on("exit", () => {
+				clearTimeout(timeout);
+				resolve();
+			});
+
+			// Try graceful termination first
+			try {
+				process.kill("SIGTERM");
+			} catch (error) {
+				// Process might already be dead
+				clearTimeout(timeout);
+				resolve();
+			}
+		});
+	}
+}
+
+// Global process manager instance
+export const processManager = new ProcessManager();
+
+// Track if signal handlers are already setup
+let signalHandlersSetup = false;
+
+// Setup signal handlers for graceful shutdown
+function setupSignalHandlers() {
+	if (signalHandlersSetup) {
+		return; // Already setup, prevent duplicates
+	}
+
+	signalHandlersSetup = true;
+
+	const signals: Array<NodeJS.Signals> = ["SIGINT", "SIGTERM", "SIGQUIT"];
+
+	for (const signal of signals) {
+		process.on(signal, async () => {
+			console.log(`\nReceived ${signal}, cleaning up...`);
+			await processManager.cleanup();
+			process.exit(0);
+		});
+	}
+
+	// Handle uncaught exceptions
+	process.on("uncaughtException", async error => {
+		console.error("Uncaught exception:", error);
+		await processManager.cleanup();
+		process.exit(1);
+	});
+
+	// Handle unhandled promise rejections
+	process.on("unhandledRejection", async (reason, promise) => {
+		console.error("Unhandled rejection at:", promise, "reason:", reason);
+		await processManager.cleanup();
+		process.exit(1);
+	});
+}
+
+// Export setup function for commands that need it
+export { setupSignalHandlers };

--- a/src/util/run.ts
+++ b/src/util/run.ts
@@ -1,32 +1,42 @@
 import kleur from "kleur";
 import { spawn, SpawnOptions } from "child_process";
 import { CLIError } from "../errors/CLIError";
+import { processManager } from "./processManager";
 
-export function run(command: string, args: ReadonlyArray<string> = []) {
+export async function run(
+	command: string,
+	args: ReadonlyArray<string> = [],
+	options: SpawnOptions = {},
+): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
 		console.log(kleur.yellow(command), ...args.map(kleur.yellow));
-		const options: SpawnOptions = { shell: true };
-		const childProcess = spawn(command, args, options);
+		const spawnOptions: SpawnOptions = { shell: true, ...options };
+		const childProcess = spawn(command, args, spawnOptions);
+
+		// Register process for cleanup
+		processManager.register(childProcess, `${command} ${args.join(" ")}`);
+
 		childProcess.stdout?.on("data", data => process.stdout.write(data));
 		childProcess.stderr?.on("data", data => process.stderr.write(data));
+
 		childProcess.on("error", err => {
-			throw err;
+			reject(new CLIError(`Failed to execute command "${command}": ${err.message}`));
 		});
+
 		childProcess.on("exit", code => {
 			if (code === 0) {
 				resolve();
 			} else {
-				reject(code);
+				reject(new CLIError(`Command "${command}" exited with code ${code}`));
 			}
 		});
+
 		childProcess.on("close", code => {
 			if (code === 0) {
 				resolve();
 			} else {
-				reject(code);
+				reject(new CLIError(`Command "${command}" closed with code ${code}`));
 			}
 		});
-	}).catch((code: number) => {
-		throw new CLIError(`Command "${command}" exited with code ${code}`);
 	});
 }

--- a/src/util/studioProcess.ts
+++ b/src/util/studioProcess.ts
@@ -1,0 +1,96 @@
+import fs from "fs/promises";
+import path from "path";
+import { LOCKFILE_NAME } from "../constants";
+import { cmd } from "./cmd";
+import { escapePowerShellPath } from "./pathSecurity";
+import { run } from "./run";
+import { runPlatform } from "./runPlatform";
+
+/**
+ * Reads process ID from a Windows lockfile using PowerShell
+ * @param windowsLockFilePath - Windows path to the lockfile
+ * @returns Process ID if found, null otherwise
+ */
+export async function readProcessIdFromWindowsLockfile(windowsLockFilePath: string): Promise<string | null> {
+	try {
+		const escapedPath = escapePowerShellPath(windowsLockFilePath);
+		const content = await cmd(`powershell.exe -Command "Get-Content -LiteralPath '${escapedPath}' -TotalCount 1"`);
+		const processId = content.trim();
+		return processId || null;
+	} catch (error) {
+		console.warn(
+			`Could not read Windows lockfile ${windowsLockFilePath}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return null;
+	}
+}
+
+/**
+ * Reads process ID from a local WSL lockfile
+ * @param lockFilePath - Path to the lockfile
+ * @returns Process ID if found, null otherwise
+ */
+export async function readProcessIdFromLockfile(lockFilePath: string): Promise<string | null> {
+	try {
+		const lockFileHandle = await fs.open(lockFilePath, "r");
+		try {
+			const buffer = Buffer.alloc(50); // Enough for a process ID
+			const { bytesRead } = await lockFileHandle.read(buffer, 0, 50, 0);
+			const content = buffer.subarray(0, bytesRead).toString();
+			const processId = content.split("\n")[0].trim();
+			return processId || null;
+		} finally {
+			await lockFileHandle.close();
+		}
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code !== "ENOENT") {
+			console.warn(`Unexpected error reading lockfile ${lockFilePath}: ${error.message}`);
+		}
+		return null;
+	}
+}
+
+/**
+ * Terminates Studio processes using platform-specific commands
+ * @param processId - The process ID to terminate
+ */
+export async function terminateStudioProcess(processId: string): Promise<void> {
+	await runPlatform({
+		darwin: () => run("kill", ["-9", processId]),
+		linux: () => run("taskkill.exe", ["/f", "/pid", processId]),
+		win32: () => run("taskkill", ["/f", "/pid", processId]),
+	});
+}
+
+/**
+ * Safely removes a Windows lockfile using PowerShell
+ * @param windowsLockFilePath - Windows path to the lockfile
+ */
+export async function cleanupWindowsLockfile(windowsLockFilePath: string): Promise<void> {
+	try {
+		const escapedPath = escapePowerShellPath(windowsLockFilePath);
+		await cmd(
+			`powershell.exe -Command "Remove-Item -LiteralPath '${escapedPath}' -Force -ErrorAction SilentlyContinue"`,
+		);
+	} catch (error) {
+		// Ignore cleanup errors - lockfile might already be gone
+	}
+}
+
+/**
+ * Safely removes the WSL lockfile with proper error handling
+ * @param projectPath - The project directory path
+ */
+export async function cleanupLockfile(projectPath: string): Promise<void> {
+	const lockFilePath = path.join(projectPath, LOCKFILE_NAME);
+
+	try {
+		await fs.rm(lockFilePath, { force: true });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code !== "ENOENT") {
+			console.warn(`Failed to clean up lockfile: ${error.message}`);
+		}
+	}
+}

--- a/src/util/studioProcess.ts
+++ b/src/util/studioProcess.ts
@@ -1,8 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import { LOCKFILE_NAME } from "../constants";
-import { cmd } from "./cmd";
-import { escapePowerShellPath } from "./pathSecurity";
+import { readWindowsFileFirstLine, removeWindowsFile } from "./windowsFileOps";
 import { run } from "./run";
 import { runPlatform } from "./runPlatform";
 
@@ -13,9 +12,7 @@ import { runPlatform } from "./runPlatform";
  */
 export async function readProcessIdFromWindowsLockfile(windowsLockFilePath: string): Promise<string | null> {
 	try {
-		const escapedPath = escapePowerShellPath(windowsLockFilePath);
-		const content = await cmd(`powershell.exe -Command "Get-Content -LiteralPath '${escapedPath}' -TotalCount 1"`);
-		const processId = content.trim();
+		const processId = await readWindowsFileFirstLine(windowsLockFilePath);
 		return processId || null;
 	} catch (error) {
 		console.warn(
@@ -70,10 +67,7 @@ export async function terminateStudioProcess(processId: string): Promise<void> {
  */
 export async function cleanupWindowsLockfile(windowsLockFilePath: string): Promise<void> {
 	try {
-		const escapedPath = escapePowerShellPath(windowsLockFilePath);
-		await cmd(
-			`powershell.exe -Command "Remove-Item -LiteralPath '${escapedPath}' -Force -ErrorAction SilentlyContinue"`,
-		);
+		await removeWindowsFile(windowsLockFilePath);
 	} catch (error) {
 		// Ignore cleanup errors - lockfile might already be gone
 	}

--- a/src/util/waitForStudio.ts
+++ b/src/util/waitForStudio.ts
@@ -1,0 +1,51 @@
+import { CLIError } from "../errors/CLIError";
+import { DEFAULT_STUDIO_WAIT_TIMEOUT, LOCKFILE_NAME } from "../constants";
+import fs from "fs";
+import { checkWindowsFileExists, isWSL } from "./wslFileSync";
+
+async function checkLockFileExists(lockFilePath: string, isCustomWindowsPath: boolean): Promise<boolean> {
+	try {
+		if (isCustomWindowsPath && isWSL()) {
+			return await checkWindowsFileExists(lockFilePath);
+		} else {
+			// Use normal fs.existsSync for local files
+			return fs.existsSync(lockFilePath);
+		}
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		throw new CLIError(`Failed to check for Studio lock file: ${lockFilePath}\nError: ${errorMessage}`);
+	}
+}
+
+export async function waitForStudio(
+	timeoutMs: number = DEFAULT_STUDIO_WAIT_TIMEOUT,
+	customLockFilePath?: string,
+): Promise<void> {
+	console.log("Waiting for Studio to open...");
+	const startTime = Date.now();
+	const lockFilePath = customLockFilePath || LOCKFILE_NAME;
+	const isCustomWindowsPath = Boolean(customLockFilePath);
+
+	while (true) {
+		const lockFileExists = await checkLockFileExists(lockFilePath, isCustomWindowsPath);
+
+		if (lockFileExists) {
+			console.log("Studio detected!");
+			return;
+		}
+
+		if (Date.now() - startTime > timeoutMs) {
+			const timeoutSeconds = Math.round(timeoutMs / 1000);
+			throw new CLIError(
+				`Studio did not open within ${timeoutSeconds} seconds. ` +
+					`Expected lock file: ${lockFilePath}\n` +
+					`Troubleshooting:\n` +
+					`• If Studio is updating, wait and try again\n` +
+					`• If Studio won't start, check Task Manager for hung processes\n` +
+					`• Verify the place file can be opened in Studio`,
+			);
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 1000)); // Check every 1 second
+	}
+}

--- a/src/util/windowsFileOps.ts
+++ b/src/util/windowsFileOps.ts
@@ -1,0 +1,99 @@
+import { cmd } from "./cmd";
+import { escapePowerShellPath } from "./pathSecurity";
+import { tempPathCache, fileMetadataCache } from "./operationCache";
+
+/**
+ * Test if a Windows path exists (cached)
+ */
+export async function testWindowsPath(windowsPath: string): Promise<boolean> {
+	const cacheKey = `test-path:${windowsPath}`;
+	return await fileMetadataCache.getOrCompute(
+		cacheKey,
+		async () => {
+			const escapedPath = escapePowerShellPath(windowsPath);
+			const result = await cmd(`powershell.exe -Command "Test-Path -LiteralPath '${escapedPath}'"`);
+			return result.trim().toLowerCase() === "true";
+		},
+		5000, // Cache for 5 seconds (file existence can change quickly)
+	);
+}
+
+/**
+ * Create a Windows directory
+ */
+export async function createWindowsDirectory(windowsPath: string): Promise<void> {
+	const escapedPath = escapePowerShellPath(windowsPath);
+	await cmd(
+		`powershell.exe -Command "if (!(Test-Path -LiteralPath '${escapedPath}')) { New-Item -ItemType Directory -LiteralPath '${escapedPath}' -Force }"`,
+	);
+}
+
+/**
+ * Copy a file
+ */
+export async function copyFileWindows(sourcePath: string, destinationPath: string): Promise<void> {
+	const escapedSource = escapePowerShellPath(sourcePath);
+	const escapedDestination = escapePowerShellPath(destinationPath);
+	await cmd(
+		`powershell.exe -Command "Copy-Item -LiteralPath '${escapedSource}' -Destination '${escapedDestination}' -Force"`,
+	);
+}
+
+/**
+ * Get file modified time (cached)
+ */
+export async function getWindowsFileModifiedTime(windowsPath: string): Promise<string> {
+	const cacheKey = `modified-time:${windowsPath}`;
+	return await fileMetadataCache.getOrCompute(
+		cacheKey,
+		async () => {
+			const escapedPath = escapePowerShellPath(windowsPath);
+			return await cmd(
+				`powershell.exe -Command "(Get-Item -LiteralPath '${escapedPath}').LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss')"`,
+			);
+		},
+		2000, // Cache for 2 seconds (modification time changes frequently)
+	);
+}
+
+/**
+ * Get Windows temp path (cached)
+ */
+export async function getWindowsTempPath(): Promise<string> {
+	const cacheKey = "windows-temp-path";
+	return await tempPathCache.getOrCompute(
+		cacheKey,
+		async () => {
+			const result = await cmd('powershell.exe -Command "[System.IO.Path]::GetTempPath()"');
+			return result.trim();
+		},
+		300000, // Cache for 5 minutes (temp path rarely changes)
+	);
+}
+
+/**
+ * Read file content (first line only)
+ */
+export async function readWindowsFileFirstLine(windowsPath: string): Promise<string> {
+	const escapedPath = escapePowerShellPath(windowsPath);
+	const result = await cmd(`powershell.exe -Command "Get-Content -LiteralPath '${escapedPath}' -TotalCount 1"`);
+	return result.trim();
+}
+
+/**
+ * Remove a Windows file
+ */
+export async function removeWindowsFile(windowsPath: string): Promise<void> {
+	const escapedPath = escapePowerShellPath(windowsPath);
+	await cmd(
+		`powershell.exe -Command "Remove-Item -LiteralPath '${escapedPath}' -Force -ErrorAction SilentlyContinue"`,
+	);
+}
+
+/**
+ * Open a Windows file with the default application
+ */
+export async function openWindowsFile(windowsPath: string): Promise<void> {
+	const escapedPath = escapePowerShellPath(windowsPath);
+	await cmd(`powershell.exe -Command "Start-Process '${escapedPath}'"`);
+}

--- a/src/util/wslFileSync.ts
+++ b/src/util/wslFileSync.ts
@@ -1,0 +1,219 @@
+import fs from "fs";
+import path from "path";
+import { cmd } from "./cmd";
+import { getWindowsPath } from "./getWindowsPath";
+import { platform } from "./runPlatform";
+import { validateWindowsPath, escapePowerShellPath } from "./pathSecurity";
+
+/**
+ * Check if we're running on WSL
+ */
+export function isWSL(): boolean {
+	return platform === "linux" && process.env.WSL_DISTRO_NAME !== undefined;
+}
+
+/**
+ * Check if WSL Windows temp workaround should be used
+ */
+export function shouldUseWindowsTemp(settings: { useWindowsTemp?: boolean }): boolean {
+	// Default to false, only enable if explicitly set to true
+	return isWSL() && settings.useWindowsTemp === true;
+}
+
+/**
+ * Get a Windows-accessible path for the given file
+ * For WSL: Returns path in Windows temp directory
+ * For other platforms: Returns original path
+ */
+export async function getWindowsSafePath(
+	filePath: string,
+	customWindowsPath?: string,
+	useWindowsTemp?: boolean,
+): Promise<string> {
+	if (!isWSL() || useWindowsTemp === false) {
+		return filePath;
+	}
+
+	const fileName = path.basename(filePath);
+
+	if (customWindowsPath) {
+		try {
+			// Validate custom Windows path before using
+			validateWindowsPath(customWindowsPath);
+			// Use custom Windows path if provided
+			const escapedPath = escapePowerShellPath(customWindowsPath);
+			const windowsCustomPath = await cmd(`wslpath -w "${escapedPath}"`);
+			return `${windowsCustomPath.trim()}\\${fileName}`;
+		} catch (error) {
+			throw new Error(
+				`Invalid Windows path configuration: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		}
+	}
+
+	// Use Windows temp directory - use PowerShell to get the temp path
+	const windowsTempDir = await cmd('powershell.exe -Command "[System.IO.Path]::GetTempPath()"');
+	const tempPath = windowsTempDir.trim();
+
+	// Create a subdirectory for rbxts-build files - use Windows path separators
+	const rbxtsBuildDir = `${tempPath}rbxts-build`;
+
+	return `${rbxtsBuildDir}\\${fileName}`;
+}
+
+/**
+ * Ensure the given file is accessible from Windows
+ * For WSL: Copies file to Windows-accessible location
+ * For other platforms: Does nothing
+ */
+export async function ensureWindowsAccessible(
+	filePath: string,
+	customWindowsPath?: string,
+	useWindowsTemp?: boolean,
+): Promise<string> {
+	if (!isWSL() || useWindowsTemp === false) {
+		return filePath;
+	}
+
+	const windowsPath = await getWindowsSafePath(filePath, customWindowsPath, useWindowsTemp);
+	const windowsDir = path.dirname(windowsPath);
+
+	// Create Windows directory if it doesn't exist using PowerShell
+	try {
+		const escapedWindowsDir = escapePowerShellPath(windowsDir);
+		await cmd(
+			`powershell.exe -Command "if (!(Test-Path -LiteralPath '${escapedWindowsDir}')) { New-Item -ItemType Directory -LiteralPath '${escapedWindowsDir}' -Force }"`,
+		);
+	} catch (error) {
+		const originalError = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to create Windows directory '${windowsDir}'. ` +
+				`This is required for Studio sync to work properly. ` +
+				`Error: ${originalError}`,
+		);
+	}
+
+	// Copy file to Windows location using PowerShell
+	try {
+		const wslSourcePath = await getWindowsPath(filePath);
+		const escapedSourcePath = escapePowerShellPath(wslSourcePath);
+		const escapedWindowsPath = escapePowerShellPath(windowsPath);
+		await cmd(
+			`powershell.exe -Command "Copy-Item -LiteralPath '${escapedSourcePath}' -Destination '${escapedWindowsPath}' -Force"`,
+		);
+	} catch (error) {
+		const originalError = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to copy file to Windows location. ` +
+				`Without this, Studio changes cannot be saved back to your project. ` +
+				`Error: ${originalError}`,
+		);
+	}
+
+	return windowsPath;
+}
+
+/**
+ * Sync file back from Windows location to WSL
+ * For WSL: Copies file from Windows location back to WSL
+ * For other platforms: Does nothing
+ */
+export async function syncFromWindows(wslPath: string, windowsPath: string): Promise<void> {
+	if (!isWSL()) {
+		return;
+	}
+
+	// Check if Windows file exists using PowerShell
+	const escapedCheckPath = escapePowerShellPath(windowsPath);
+	const windowsFileExists = await cmd(`powershell.exe -Command "Test-Path -LiteralPath '${escapedCheckPath}'"`)
+		.then(result => result.trim().toLowerCase() === "true")
+		.catch(() => false);
+
+	if (!windowsFileExists) {
+		throw new Error("Windows file does not exist or is not accessible");
+	}
+
+	// Copy from Windows back to WSL using PowerShell
+	try {
+		const wslTargetPath = await getWindowsPath(wslPath);
+		const escapedSyncWindowsPath = escapePowerShellPath(windowsPath);
+		const escapedWslTargetPath = escapePowerShellPath(wslTargetPath);
+		await cmd(
+			`powershell.exe -Command "Copy-Item -LiteralPath '${escapedSyncWindowsPath}' -Destination '${escapedWslTargetPath}' -Force"`,
+		);
+	} catch (error) {
+		throw new Error("Failed to sync file from Windows to WSL");
+	}
+}
+
+/**
+ * Check if Windows file is newer than WSL file
+ */
+export async function isWindowsFileNewer(wslPath: string, windowsPath: string): Promise<boolean> {
+	if (!isWSL()) {
+		return false;
+	}
+
+	try {
+		// Get WSL file stats
+		const wslStats = fs.existsSync(wslPath) ? fs.statSync(wslPath) : null;
+
+		// Get Windows file stats using PowerShell
+		const escapedStatsPath = escapePowerShellPath(windowsPath);
+		const windowsStatsCmd = `powershell.exe -Command "(Get-Item -LiteralPath '${escapedStatsPath}').LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss')"`;
+		const windowsDateStr = await cmd(windowsStatsCmd).catch(() => null);
+
+		if (!wslStats || !windowsDateStr) {
+			return windowsDateStr !== null; // If only Windows file exists, it's "newer"
+		}
+
+		// Parse Windows date/time using PowerShell formatted output
+		const windowsModified = new Date(windowsDateStr.trim());
+
+		return windowsModified > wslStats.mtime;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Check if a file exists in Windows using PowerShell
+ */
+export async function checkWindowsFileExists(windowsPath: string): Promise<boolean> {
+	try {
+		const escapedPath = escapePowerShellPath(windowsPath);
+		const result = await cmd(`powershell.exe -Command "Test-Path -LiteralPath '${escapedPath}'"`);
+		return result.trim().toLowerCase() === "true";
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Wait for a Windows file to exist, with timeout
+ */
+export async function waitForWindowsFile(windowsPath: string, timeoutMs: number = 60000): Promise<boolean> {
+	const startTime = Date.now();
+	const checkInterval = 1000; // Check every 1 second
+	let lastProgressTime = 0;
+	const progressInterval = 10000; // Show progress every 10 seconds
+
+	while (Date.now() - startTime < timeoutMs) {
+		const exists = await checkWindowsFileExists(windowsPath);
+		if (exists) {
+			return true;
+		}
+
+		// Show progress every 10 seconds
+		const elapsed = Date.now() - startTime;
+		if (elapsed - lastProgressTime >= progressInterval) {
+			const remaining = Math.ceil((timeoutMs - elapsed) / 1000);
+			console.log(`Still waiting for Studio to open... (${remaining}s remaining)`);
+			lastProgressTime = elapsed;
+		}
+
+		await new Promise(resolve => setTimeout(resolve, checkInterval));
+	}
+
+	return false; // Timeout reached
+}


### PR DESCRIPTION
## Summary

This PR implements a comprehensive syncback system for rbxts-build, allowing developers to sync changes from Roblox Studio back to their source files.

### Key Features
- **New `syncback` command** with single-run and continuous monitoring modes
- **Lune-based monitoring script** for efficient file change detection
- **Full WSL/Windows integration** with existing temp file workflows
- **Dependency validation** for Rojo UpliftGames fork and Lune runtime
- **Process management** with graceful cleanup and signal handling
- **Operation caching** to improve performance on WSL systems
- **Studio wait functionality** with configurable timeouts

### Usage Examples
```bash
# Single syncback operation
rbxts-build syncback

# Continuous monitoring mode
rbxts-build syncback --watch

# Wait for Studio to open before starting
rbxts-build syncback --watch --wait-for-studio
```

### Configuration
New settings available in `package.json`:
```json
{
  "rbxts-build": {
    "syncback": true,
    "studioWaitTimeout": 60000,
    "syncbackArgs": ["--non-interactive"]
  }
}
```

## Dependencies

⚠️ **This PR depends on #11 being merged first** as it builds on the WSL file sync infrastructure.

The syncback functionality requires:
- Rojo with syncback support (UpliftGames fork)
- Lune v0.9.0+ for continuous monitoring
- All existing rbxts-build dependencies

## Test Plan

- [ ] Test single syncback operation on local projects
- [ ] Verify continuous monitoring detects Studio file changes
- [ ] Confirm WSL integration works with Windows temp files
- [ ] Test dependency validation with missing/outdated tools
- [ ] Verify graceful shutdown with Ctrl+C during watch mode
- [ ] Test Studio wait functionality with various timeout settings
- [ ] Confirm process cleanup prevents zombie processes